### PR TITLE
[BST-10] Auth 온보딩(회원가입/로그인 + 비밀번호 찾기/재설정) 플로우 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vue-problem-board",
       "version": "0.0.1",
       "dependencies": {
+        "axios": "^1.13.2",
         "flowbite": "^2.5.2",
         "flowbite-vue": "^0.2.2",
         "vue": "^3.5.0",
@@ -2548,6 +2549,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.22",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
@@ -2584,6 +2591,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2702,6 +2721,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2886,6 +2918,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -3051,6 +3095,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3073,6 +3126,20 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3150,12 +3217,57 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4011,6 +4123,26 @@
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4026,6 +4158,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4063,6 +4211,43 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4148,6 +4333,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4162,6 +4359,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -4926,6 +5150,15 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4961,6 +5194,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -5621,6 +5875,12 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "axios": "^1.13.2",
     "flowbite": "^2.5.2",
     "flowbite-vue": "^0.2.2",
     "vue": "^3.5.0",

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,0 +1,103 @@
+import httpClient from "./httpClient";
+// JWT 도입 시 아래처럼 교체:
+// import httpClient, { setAccessToken, clearAccessToken } from "./httpClient";
+
+/**
+ * 1) 지금 당장 쓸 버전 (ID/PW + 세션)
+ *    - 서버가 세션 쿠키를 내려주거나, { user } 형태 응답을 내려준다고 가정
+ */
+export async function loginWithIdPw({ id, password }) {
+  const response = await httpClient.post("/auth/login", {
+    id, // 이메일을 ID로 쓰면 프론트에서 email을 그대로 넣으면 됨
+    password,
+  });
+
+  // 예시: { user: { id, nickname, ... } }
+  return response.data;
+}
+
+/**
+ * 회원가입 (ID/PW 기반)
+ */
+export async function signupWithIdPw({ email, nickname, password }) {
+  const response = await httpClient.post("/auth/signup", {
+    email,
+    nickname,
+    password,
+  });
+
+  return response.data;
+}
+
+/**
+ * 닉네임(username) 중복 확인
+ * GET /api/v1/auth/duplicate/username?username=홍길동
+ * -> baseURL이 /api 이므로 여기서는 /v1/... 로 호출
+ */
+export async function checkUsernameDuplicate({ username }) {
+  const response = await httpClient.get("/v1/auth/duplicate/username", {
+    params: { username },
+  });
+
+  // 백엔드 응답 예시(가정):
+  // { duplicated: true } 또는 { available: false } 등
+  return response.data;
+}
+
+/**
+ * 로그아웃 (세션 기반)
+ */
+export async function logout() {
+  const response = await httpClient.post("/auth/logout");
+  return response.data;
+}
+
+/**
+ * 비밀번호 재설정 메일 발송
+ */
+export async function forgotPassword({ email }) {
+  const response = await httpClient.post("/auth/forgot-password", { email });
+  return response.data;
+}
+
+/**
+ * 비밀번호 재설정
+ */
+export async function resetPassword({ token, newPassword }) {
+  const response = await httpClient.post("/auth/reset-password", {
+    token,
+    newPassword,
+  });
+  return response.data;
+}
+
+/**
+ * 2) 나중에 JWT로 전환할 때 쓸 예시 (현재는 주석으로만 보관)
+ *
+ * JWT 적용 시, httpClient에 accessToken을 실어 보내고,
+ * refreshToken은 httpOnly 쿠키나 별도 저장 전략을 사용.
+ *
+ * // import httpClient, { setAccessToken, clearAccessToken } from "./httpClient";
+ *
+ * export async function loginWithJwt({ id, password }) {
+ *   const response = await httpClient.post("/auth/login", { id, password });
+ *   const { accessToken, refreshToken, user } = response.data;
+ *
+ *   setAccessToken(accessToken);
+ *   // refreshToken은 브라우저 저장소(localStorage)보다는 httpOnly 쿠키 권장
+ *
+ *   return { accessToken, refreshToken, user };
+ * }
+ *
+ * export async function refreshAccessToken() {
+ *   const response = await httpClient.post("/auth/refresh");
+ *   const { accessToken } = response.data;
+ *   setAccessToken(accessToken);
+ *   return accessToken;
+ * }
+ *
+ * export async function logoutJwt() {
+ *   await httpClient.post("/auth/logout");
+ *   clearAccessToken();
+ * }
+ */

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -1,0 +1,48 @@
+import axios from "axios";
+
+// .env에 VITE_API_BASE_URL 설정해두면 거기를 기본으로 사용
+// 예: VITE_API_BASE_URL=http://localhost:8080/api
+const httpClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:8080/api",
+  withCredentials: true, // 쿠키/세션 방식도 고려 (안 쓰면 그냥 무시됨)
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// ===== JWT 전환 대비용: accessToken 관리 =====
+let accessToken = null;
+
+// 지금은 안 써도 됨. 나중에 로그인 성공 시 여기로 토큰 넣으면 됨.
+export function setAccessToken(token) {
+  accessToken = token;
+}
+
+// 로그아웃/만료 시 호출
+export function clearAccessToken() {
+  accessToken = null;
+}
+
+// === request 인터셉터: 토큰이 있으면 Authorization 헤더에 붙이기 ===
+httpClient.interceptors.request.use(
+  (config) => {
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+// === response 인터셉터: 401 처리, refresh 토큰 로직 등은 나중에 여기서 ===
+// 예시용 빈 껍데기만 두고, 추후 JWT 붙일 때 구현
+httpClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    // 나중에:
+    // if (error.response?.status === 401) { ...refresh 처리... }
+    return Promise.reject(error);
+  },
+);
+
+export default httpClient;

--- a/src/api/mockAuthApi.js
+++ b/src/api/mockAuthApi.js
@@ -1,0 +1,267 @@
+const STORAGE_KEY_USERS = "bst:mockUsers";
+const STORAGE_KEY_CURRENT_USER = "bst:currentUser";
+const STORAGE_KEY_ACCESS_TOKEN = "bst:accessToken";
+const STORAGE_KEY_RESET_TOKENS = "bst:resetTokens";
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function loadUsers() {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY_USERS);
+    if (!raw) return [];
+    return JSON.parse(raw);
+  } catch (e) {
+    console.error("Failed to parse users from localStorage", e);
+    return [];
+  }
+}
+
+function saveUsers(users) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY_USERS, JSON.stringify(users));
+}
+
+function loadResetTokens() {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY_RESET_TOKENS);
+    if (!raw) return [];
+    return JSON.parse(raw);
+  } catch (e) {
+    console.error("Failed to parse reset tokens", e);
+    return [];
+  }
+}
+
+function saveResetTokens(tokens) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY_RESET_TOKENS, JSON.stringify(tokens));
+}
+
+// 간단한 랜덤 토큰 생성 (목 용도)
+function generateToken(prefix) {
+  return (
+    prefix +
+    "-" +
+    Math.random().toString(36).slice(2) +
+    "-" +
+    Date.now().toString(36)
+  );
+}
+
+/**
+ * 닉네임(=username) 중복 확인 mock
+ *   - 실제 엔드포인트: GET /api/v1/auth/duplicate/username?username=...
+ */
+export async function mockCheckUsernameDuplicate({ username }) {
+  await delay(200);
+
+  const users = loadUsers();
+  const duplicated = users.some((u) => u.nickname === username);
+
+  // 실제 API와 비슷한 형태로 가정
+  return {
+    duplicated,
+    available: !duplicated,
+  };
+}
+
+// ===== 회원가입 (ID/PW 기반) =====
+export async function mockSignup({ email, nickname, password }) {
+  await delay(500);
+
+  const users = loadUsers();
+  const exists = users.some((u) => u.email === email);
+
+  if (exists) {
+    const error = new Error("이미 사용 중인 이메일입니다.");
+    error.code = "EMAIL_EXISTS";
+    throw error;
+  }
+
+  const newUser = {
+    id: Date.now(),
+    email,
+    nickname,
+    password, // ⚠️ 실제 프로덕션에서는 평문 저장 금지 (BCrypt 등 사용)
+  };
+
+  const nextUsers = [...users, newUser];
+  saveUsers(nextUsers);
+
+  // 지금은 세션/쿠키 기반이라고 가정해서 user 정보만 반환
+  return {
+    user: {
+      id: newUser.id,
+      email: newUser.email,
+      nickname: newUser.nickname,
+    },
+  };
+
+  /**
+   * 나중에 JWT로 전환하면, 회원가입 후 토큰까지 함께 내려줄 수도 있음:
+   *
+   * return {
+   *   user: { ... },
+   *   accessToken: "mock-access-token-" + newUser.id,
+   *   refreshToken: "mock-refresh-token-" + newUser.id,
+   * };
+   */
+}
+
+// ===== 로그인 (ID/PW 기반) =====
+export async function mockLogin({ email, password }) {
+  await delay(500);
+
+  const users = loadUsers();
+  const user = users.find((u) => u.email === email && u.password === password);
+
+  if (!user) {
+    const error = new Error("이메일 또는 비밀번호가 올바르지 않습니다.");
+    error.code = "INVALID_CREDENTIALS";
+    throw error;
+  }
+
+  // JWT 도입 시:
+  // const accessToken = "mock-access-token-" + user.id;
+
+  if (typeof window !== "undefined") {
+    // 프론트 전역 상태 복구용으로 현재 유저 정보만 저장
+    window.localStorage.setItem(
+      STORAGE_KEY_CURRENT_USER,
+      JSON.stringify({
+        id: user.id,
+        email: user.email,
+        nickname: user.nickname,
+      }),
+    );
+
+    // 나중에 JWT 쓰면 토큰도 저장 가능
+    // window.localStorage.setItem(STORAGE_KEY_ACCESS_TOKEN, accessToken);
+  }
+
+  // 지금은 user만 반환 (세션 쿠키 기반 가정)
+  return {
+    user: {
+      id: user.id,
+      email: user.email,
+      nickname: user.nickname,
+    },
+    // JWT 도입 시 함께 반환:
+    // accessToken,
+    // refreshToken: "mock-refresh-token-" + user.id,
+  };
+}
+
+export function mockGetCurrentUser() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY_CURRENT_USER);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (e) {
+    console.error("Failed to parse currentUser from localStorage", e);
+    return null;
+  }
+}
+
+export function mockLogout() {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(STORAGE_KEY_CURRENT_USER);
+
+  // JWT 도입 시 accessToken 제거
+  window.localStorage.removeItem(STORAGE_KEY_ACCESS_TOKEN);
+}
+
+// ===== 비밀번호 재설정 요청 (비밀번호 찾기) =====
+export async function mockForgotPassword({ email }) {
+  await delay(500);
+
+  const users = loadUsers();
+  const user = users.find((u) => u.email === email);
+
+  // 실제 서비스에서는 "존재/미존재" 노출 안 하는 게 베스트 프랙티스.
+  // 여기서는 데모를 위해, 존재할 때만 토큰을 만들어 줌.
+  if (!user) {
+    return {
+      ok: true,
+      token: null, // 이메일이 없어도 같은 메시지 보여주기용
+    };
+  }
+
+  const tokens = loadResetTokens().filter((t) => t.userId !== user.id);
+
+  const token = generateToken("reset");
+  const expiresAt = Date.now() + 15 * 60 * 1000; // 15분 유효
+
+  tokens.push({
+    token,
+    userId: user.id,
+    expiresAt,
+  });
+
+  saveResetTokens(tokens);
+
+  // ⚠️ 실제 서비스에서는 이 토큰을 이메일로 보내고,
+  // 프론트에는 토큰을 리턴하지 않는다.
+  // 지금은 데모를 위해 리턴해서 바로 reset 화면으로 이동할 수 있게 함.
+  return {
+    ok: true,
+    token,
+  };
+}
+
+// ===== 비밀번호 실제 재설정 =====
+export async function mockResetPassword({ token, newPassword }) {
+  await delay(500);
+
+  const tokens = loadResetTokens();
+  const entry = tokens.find((t) => t.token === token);
+
+  if (!entry) {
+    const error = new Error("유효하지 않거나 만료된 링크입니다.");
+    error.code = "INVALID_OR_EXPIRED_TOKEN";
+    throw error;
+  }
+
+  if (entry.expiresAt < Date.now()) {
+    const error = new Error("비밀번호 재설정 링크가 만료되었습니다.");
+    error.code = "INVALID_OR_EXPIRED_TOKEN";
+    throw error;
+  }
+
+  const users = loadUsers();
+  const idx = users.findIndex((u) => u.id === entry.userId);
+
+  if (idx === -1) {
+    const error = new Error("사용자를 찾을 수 없습니다.");
+    error.code = "USER_NOT_FOUND";
+    throw error;
+  }
+
+  users[idx].password = newPassword; // ⚠️ 목이라 그냥 저장
+  saveUsers(users);
+
+  // 해당 토큰은 한 번만 사용 가능하도록 제거
+  const nextTokens = tokens.filter((t) => t.token !== token);
+  saveResetTokens(nextTokens);
+
+  // 현재 로그인 상태도 초기화 (단일 사용자 기준)
+  mockLogout();
+
+  return { ok: true };
+}
+
+/**
+ * ===== 나중에 JWT로 전환할 때 예시 =====
+ *
+ * // 로그인 시
+ * // const { user, accessToken, refreshToken } = await mockLogin({ email, password });
+ * // window.localStorage.setItem(STORAGE_KEY_ACCESS_TOKEN, accessToken);
+ *
+ * // httpClient 인터셉터에서 ACCESS_TOKEN을 Authorization 헤더로 붙이고,
+ * // refreshToken은 httpOnly 쿠키 or 별도 저장전략 사용.
+ */

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,13 +4,42 @@ import ProblemBoard from "../components/ProblemBoard.vue";
 import GroupList from "../components/group/GroupList.vue";
 import GroupCreate from "../components/group/GroupCreate.vue";
 import GroupEdit from "../components/group/GroupEdit.vue";
+
 import LandingMain from "../views/LandingMain.vue";
+import LoginView from "../views/LoginView.vue";
+import SignupView from "../views/SignupView.vue";
+
+import ForgotPasswordView from "../views/ForgotPasswordView.vue";
+import ResetPasswordView from "../views/ResetPasswordView.vue";
 
 const routes = [
   {
     path: "/",
     name: "Home",
     component: LandingMain,
+    meta: { guestOnly: true },
+  },
+  {
+    path: "/login",
+    name: "Login",
+    component: LoginView,
+    meta: { guestOnly: true },
+  },
+  {
+    path: "/signup",
+    name: "Signup",
+    component: SignupView,
+    meta: { guestOnly: true },
+  },
+  {
+    path: "/forgot-password",
+    name: "ForgotPassword",
+    component: ForgotPasswordView,
+  },
+  {
+    path: "/reset-password",
+    name: "ResetPassword",
+    component: ResetPasswordView,
   },
   {
     path: "/groups",

--- a/src/views/ForgotPasswordView.vue
+++ b/src/views/ForgotPasswordView.vue
@@ -1,0 +1,198 @@
+<script setup>
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+
+// TODO: 나중에 실제 백엔드 붙일 때 쓸 API
+// import { forgotPassword } from "../api/authApi";
+
+// TODO: 지금은 mock 사용 (백엔드 붙기 전까지)
+import { mockForgotPassword } from "../api/mockAuthApi";
+
+const router = useRouter();
+
+const email = ref("");
+const isSubmitting = ref(false);
+const errorMessage = ref("");
+const infoMessage = ref("");
+const devResetToken = ref(""); // 데모용: 바로 reset 화면으로 이동할 때 사용
+
+function validate() {
+  errorMessage.value = "";
+  infoMessage.value = "";
+
+  if (!email.value.trim()) {
+    errorMessage.value = "가입하신 이메일을 입력해주세요.";
+    return false;
+  }
+  return true;
+}
+
+async function handleSubmit() {
+  if (!validate()) return;
+
+  isSubmitting.value = true;
+  errorMessage.value = "";
+  infoMessage.value = "";
+  devResetToken.value = "";
+
+  try {
+    /** TODO:
+     * ================================
+     * 1) 지금: mock API 호출
+     * ================================
+     * - localStorage에 저장된 mock 유저 목록에서 토큰 생성
+     * - { ok: true, token } 형태로 응답
+     */
+    const res = await mockForgotPassword({ email: email.value });
+
+    /** TODO:
+     * ================================
+     * 2) 나중: 실제 백엔드 연동
+     * ================================
+     * 백엔드에서 /auth/forgot-password 같은 엔드포인트를 제공한다고 가정.
+     *
+     * const res = await forgotPassword({ email: email.value });
+     *
+     * // 기대 응답:
+     * // { ok: true } 또는 { ok: true, message: "메일 발송 완료" }
+     *
+     * 실제 서비스에서는 토큰을 프론트로 보내지 않고,
+     * 서버에서 바로 이메일을 발송하는 패턴
+     * 이 화면에서는 "메일을 보냈습니다" 정도의 안내
+     */
+
+    infoMessage.value =
+      "입력하신 이메일로 비밀번호 재설정 안내를 보냈습니다. (이메일이 등록되어 있다면)";
+
+    // TODO:
+    // ⚠️ 실제 서비스에서는 token을 받지 않는다.
+    // 지금은 개발 편의상, mock이 token을 리턴해주기 때문에
+    // 바로 reset 화면으로 이동할 수 있도록 devResetToken에 저장.
+    if (res.token) {
+      devResetToken.value = res.token;
+      // 실제 서비스에서는 이메일을 열고 사용자가 링크를 클릭하므로
+      // 아래처럼 바로 이동시키는 코드는 사용하지 않음
+      // router.push({ name: "ResetPassword", query: { token: res.token } });
+    }
+  } catch (e) {
+    errorMessage.value =
+      "요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+    console.log(e); // TODO: remove this code and apply log
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+// TODO: 지금은 mock 사용 (백엔드 붙기 전까지)
+function goToResetNow() {
+  if (!devResetToken.value) return;
+  router.push({
+    name: "ResetPassword",
+    query: { token: devResetToken.value },
+  });
+}
+
+function goToLogin() {
+  router.push({ name: "Login" });
+}
+</script>
+
+<template>
+  <div
+    class="min-h-screen bg-gradient-to-b from-yellow-50/70 via-white to-gray-50 text-gray-900 flex flex-col"
+  >
+    <header class="w-full max-w-5xl mx-auto px-4 sm:px-6 pt-6">
+      <h1 class="text-xl font-semibold tracking-tight">BlueStrongMountain</h1>
+    </header>
+
+    <main class="flex-1 flex items-center justify-center px-4 sm:px-6 pb-12">
+      <div
+        class="w-full max-w-md bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-yellow-100/60 px-6 py-8 sm:px-8"
+      >
+        <h2 class="text-2xl font-bold text-gray-900 tracking-tight">
+          비밀번호 찾기
+        </h2>
+        <p class="mt-2 text-sm text-gray-600">
+          가입하신 이메일로 비밀번호 재설정 링크를 보내드릴게요.
+        </p>
+
+        <p
+          v-if="errorMessage"
+          class="mt-4 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2"
+        >
+          {{ errorMessage }}
+        </p>
+
+        <p
+          v-if="infoMessage"
+          class="mt-4 text-sm text-green-700 bg-green-50 border border-green-100 rounded-lg px-3 py-2"
+        >
+          {{ infoMessage }}
+        </p>
+
+        <form
+          class="mt-6 space-y-4"
+          @submit.prevent="handleSubmit"
+        >
+          <div>
+            <label
+              for="forgot-email"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              이메일
+            </label>
+            <input
+              id="forgot-email"
+              v-model="email"
+              type="email"
+              autocomplete="email"
+              required
+              class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <button
+            type="submit"
+            :disabled="isSubmitting"
+            class="mt-2 inline-flex w-full items-center justify-center rounded-lg bg-yellow-400 px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            <span v-if="!isSubmitting">재설정 링크 보내기</span>
+            <span v-else>요청 중...</span>
+          </button>
+        </form>
+
+        <!-- 데모용 바로가기 -->
+        <div
+          v-if="devResetToken"
+          class="mt-6 text-xs text-gray-500 bg-gray-50 border border-dashed border-gray-200 rounded-xl px-3 py-3 space-y-2"
+        >
+          <p class="font-medium text-gray-700">
+            개발용 데모:
+            <span class="font-normal text-gray-500">
+              실제 서비스에서는 이메일로 링크가 전송되지만,<br />
+              지금은 바로 새 비밀번호 설정 화면으로 이동할 수 있어요.
+            </span>
+          </p>
+          <button
+            type="button"
+            class="inline-flex items-center rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100"
+            @click="goToResetNow"
+          >
+            새 비밀번호 설정하러 가기
+          </button>
+        </div>
+
+        <div class="mt-6 flex items-center justify-between text-xs sm:text-sm">
+          <button
+            type="button"
+            class="text-gray-500 hover:text-gray-700 underline-offset-2 hover:underline"
+            @click="goToLogin"
+          >
+            로그인 화면으로 돌아가기
+          </button>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,173 @@
+<script setup>
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+// TODO: 실제 API 연동 버전 (JWT 없는 ID/PW) 아니면 /stores/authStore
+// import { loginWithIdPw } from "../api/authApi";
+
+// TODO: mock 버전 (백엔드 붙기 전까지 사용)
+import { mockLogin } from "../api/mockAuthApi";
+
+const router = useRouter();
+
+const email = ref("");
+const password = ref("");
+const isSubmitting = ref(false);
+const errorMessage = ref("");
+
+function validate() {
+  errorMessage.value = "";
+
+  if (!email.value.trim() || !password.value.trim()) {
+    errorMessage.value = "이메일과 비밀번호를 모두 입력해주세요.";
+    return false;
+  }
+
+  if (password.value.length < 8) {
+    errorMessage.value = "비밀번호는 최소 8자 이상이어야 합니다.";
+    return false;
+  }
+
+  return true;
+}
+
+async function handleSubmit() {
+  if (!validate()) return;
+
+  isSubmitting.value = true;
+  try {
+    // TODO: ===== 1) 지금: mock + ID/PW 기반 =====
+    const { user /*, accessToken */ } = await mockLogin({
+      email: email.value,
+      password: password.value,
+    });
+    console.log("로그인 성공 (mock)", user);
+    // 나중에 JWT 도입 시 accessToken 활용:
+    // authStore.setAuth(user, accessToken);
+
+    // ===== 2) 나중에: 실제 API + 세션(ID/PW) =====
+    // const { user } = await loginWithIdPw({
+    //   id: email.value, // 서버에서 ID로 쓸 값 (이메일이면 그대로)
+    //   password: password.value,
+    // });
+
+    router.push({ name: "GroupList" });
+  } catch (e) {
+    errorMessage.value = "이메일 또는 비밀번호가 올바르지 않습니다.";
+    console.log(e); // TODO: remove and apply logging
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+function goToHome() {
+  router.push({ name: "Home" });
+}
+
+function goToForgotPassword() {
+  router.push({ name: "ForgotPassword" });
+}
+
+function goToSignup() {
+  router.push({ name: "Signup" });
+}
+</script>
+
+<template>
+  <div
+    class="min-h-screen bg-gradient-to-b from-yellow-50/70 via-white to-gray-50 text-gray-900 flex flex-col"
+  >
+    <header class="w-full max-w-5xl mx-auto px-4 sm:px-6 pt-6">
+      <h1
+        class="text-xl font-semibold tracking-tight cursor-pointer"
+        @click="goToHome"
+      >
+        BlueStrongMountain
+      </h1>
+    </header>
+
+    <main class="flex-1 flex items-center justify-center px-4 sm:px-6 pb-12">
+      <div
+        class="w-full max-w-md bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-yellow-100/60 px-6 py-8 sm:px-8"
+      >
+        <h2 class="text-2xl font-bold text-gray-900 tracking-tight">로그인</h2>
+        <p class="mt-2 text-sm text-gray-600">
+          알고리즘 보드를 관리하려면 먼저 로그인하세요.
+        </p>
+
+        <p
+          v-if="errorMessage"
+          class="mt-4 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2"
+        >
+          {{ errorMessage }}
+        </p>
+
+        <form
+          class="mt-6 space-y-4"
+          @submit.prevent="handleSubmit"
+        >
+          <div>
+            <label
+              for="email"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              이메일
+            </label>
+            <input
+              id="email"
+              v-model="email"
+              type="email"
+              autocomplete="email"
+              required
+              class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div>
+            <label
+              for="password"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              비밀번호
+            </label>
+            <input
+              id="password"
+              v-model="password"
+              type="password"
+              autocomplete="current-password"
+              required
+              class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+              placeholder="8자 이상 입력해주세요"
+            />
+          </div>
+
+          <button
+            type="submit"
+            :disabled="isSubmitting"
+            class="mt-2 inline-flex w-full items-center justify-center rounded-lg bg-yellow-400 px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            <span v-if="!isSubmitting">로그인</span>
+            <span v-else>로그인 중...</span>
+          </button>
+        </form>
+
+        <div class="mt-6 flex items-center justify-between text-xs sm:text-sm">
+          <button
+            type="button"
+            class="text-gray-500 hover:text-gray-700 underline-offset-2 hover:underline"
+            @click="goToForgotPassword"
+          >
+            비밀번호를 잊으셨나요?
+          </button>
+          <button
+            type="button"
+            class="text-gray-800 font-medium hover:text-yellow-600 underline-offset-2 hover:underline"
+            @click="goToSignup"
+          >
+            아직 계정이 없으신가요?
+          </button>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>

--- a/src/views/ResetPasswordView.vue
+++ b/src/views/ResetPasswordView.vue
@@ -1,0 +1,229 @@
+<script setup>
+import { ref, computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+// TODO: 나중에 실제 백엔드 붙일 때 쓸 API
+// import { resetPassword } from "../api/authApi";
+
+// TODO: 지금은 mock 사용
+import { mockResetPassword } from "../api/mockAuthApi";
+
+const route = useRoute();
+const router = useRouter();
+
+const token = computed(() => {
+  const t = route.query.token;
+  return typeof t === "string" ? t : "";
+});
+const hasToken = computed(() => token.value.length > 0);
+
+const password = ref("");
+const passwordConfirm = ref("");
+const isSubmitting = ref(false);
+const errorMessage = ref("");
+const successMessage = ref("");
+
+function validate() {
+  errorMessage.value = "";
+  successMessage.value = "";
+
+  if (!hasToken.value) {
+    errorMessage.value = "유효하지 않은 접근입니다. 링크를 다시 확인해주세요.";
+    return false;
+  }
+
+  if (password.value.length < 8) {
+    errorMessage.value = "비밀번호는 최소 8자 이상이어야 합니다.";
+    return false;
+  }
+
+  if (password.value !== passwordConfirm.value) {
+    errorMessage.value = "비밀번호와 비밀번호 확인이 일치하지 않습니다.";
+    return false;
+  }
+
+  return true;
+}
+
+async function handleSubmit() {
+  if (!validate()) return;
+
+  isSubmitting.value = true;
+  errorMessage.value = "";
+  successMessage.value = "";
+
+  try {
+    /**
+     * TODO: ================================
+     * 1) 지금: mock API 호출
+     * ================================
+     * localStorage에 저장된 resetTokens에서 토큰 검증 후
+     * 해당 유저의 password를 교체하는 방식.
+     */
+    await mockResetPassword({
+      token: token.value,
+      newPassword: password.value,
+    });
+
+    /** TODO:
+     * ================================
+     * 2) 나중: 실제 백엔드 연동
+     * ================================
+     * 백엔드에서 /auth/reset-password 같은 엔드포인트를 제공한다고 가정.
+     *
+     * await resetPassword({
+     *   token: token.value,
+     *   newPassword: password.value,
+     * });
+     *
+     * // 기대 응답:
+     * // { ok: true } 또는 { ok: true, message: "비밀번호 변경 완료" }
+     *
+     * 서버에서는 토큰 유효성/만료 여부를 확인하고,
+     * 비밀번호를 해싱(BCrypt/Argon2 등)해서 저장한 뒤
+     * 기존 세션/토큰을 모두 무효화해야 함.
+     */
+
+    successMessage.value =
+      "비밀번호가 변경되었습니다. 새 비밀번호로 다시 로그인해 주세요.";
+    password.value = "";
+    passwordConfirm.value = "";
+  } catch (e) {
+    if (e.code === "INVALID_OR_EXPIRED_TOKEN") {
+      errorMessage.value = e.message;
+    } else {
+      errorMessage.value =
+        "비밀번호를 변경하는 중 문제가 발생했습니다. 링크를 다시 요청해 주세요.";
+    }
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+function goToLogin() {
+  router.push({ name: "Login" });
+}
+
+function goToForgot() {
+  router.push({ name: "ForgotPassword" });
+}
+</script>
+
+<template>
+  <div
+    class="min-h-screen bg-gradient-to-b from-yellow-50/70 via-white to-gray-50 text-gray-900 flex flex-col"
+  >
+    <header class="w-full max-w-5xl mx-auto px-4 sm:px-6 pt-6">
+      <h1 class="text-xl font-semibold tracking-tight">BlueStrongMountain</h1>
+    </header>
+
+    <main class="flex-1 flex items-center justify-center px-4 sm:px-6 pb-12">
+      <div
+        class="w-full max-w-md bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-yellow-100/60 px-6 py-8 sm:px-8"
+      >
+        <h2 class="text-2xl font-bold text-gray-900 tracking-tight">
+          새 비밀번호 설정
+        </h2>
+        <p class="mt-2 text-sm text-gray-600">
+          새로운 비밀번호를 입력해 주세요.
+        </p>
+
+        <p
+          v-if="errorMessage"
+          class="mt-4 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2"
+        >
+          {{ errorMessage }}
+        </p>
+
+        <p
+          v-if="successMessage"
+          class="mt-4 text-sm text-green-700 bg-green-50 border border-green-100 rounded-lg px-3 py-2"
+        >
+          {{ successMessage }}
+        </p>
+
+        <div
+          v-if="hasToken"
+          class="mt-6"
+        >
+          <form
+            class="space-y-4"
+            @submit.prevent="handleSubmit"
+          >
+            <div>
+              <label
+                for="new-password"
+                class="block text-sm font-medium text-gray-700 mb-1"
+              >
+                새 비밀번호
+              </label>
+              <input
+                id="new-password"
+                v-model="password"
+                type="password"
+                autocomplete="new-password"
+                required
+                class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+                placeholder="8자 이상, 안전한 비밀번호"
+              />
+              <p class="mt-1 text-xs text-gray-400">
+                영문, 숫자, 특수문자를 조합하면 더 안전해요.
+              </p>
+            </div>
+
+            <div>
+              <label
+                for="new-password-confirm"
+                class="block text-sm font-medium text-gray-700 mb-1"
+              >
+                새 비밀번호 확인
+              </label>
+              <input
+                id="new-password-confirm"
+                v-model="passwordConfirm"
+                type="password"
+                autocomplete="new-password"
+                required
+                class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+                placeholder="비밀번호를 한 번 더 입력해주세요"
+              />
+            </div>
+
+            <button
+              type="submit"
+              :disabled="isSubmitting"
+              class="mt-2 inline-flex w-full items-center justify-center rounded-lg bg-yellow-400 px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            >
+              <span v-if="!isSubmitting">비밀번호 변경하기</span>
+              <span v-else>변경 중...</span>
+            </button>
+          </form>
+        </div>
+
+        <div
+          v-else
+          class="mt-6 text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded-xl px-3 py-3"
+        >
+          <p>유효하지 않은 링크입니다. 비밀번호 찾기부터 다시 진행해 주세요.</p>
+        </div>
+
+        <div class="mt-6 flex items-center justify-between text-xs sm:text-sm">
+          <button
+            type="button"
+            class="text-gray-500 hover:text-gray-700 underline-offset-2 hover:underline"
+            @click="goToForgot"
+          >
+            비밀번호 찾기로 돌아가기
+          </button>
+          <button
+            type="button"
+            class="text-gray-800 font-medium hover:text-yellow-600 underline-offset-2 hover:underline"
+            @click="goToLogin"
+          >
+            로그인 하러 가기
+          </button>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>

--- a/src/views/SignupView.vue
+++ b/src/views/SignupView.vue
@@ -1,0 +1,284 @@
+<script setup>
+import { ref, watch } from "vue";
+import { useRouter } from "vue-router";
+// TODO: 실제 회원가입 API (ID/PW 기반)
+// import { signupWithIdPw, checkUsernameDuplicate } from "@/api/authApi";
+
+// TODO: TODO: mock 버전
+import { mockSignup, mockCheckUsernameDuplicate } from "../api/mockAuthApi";
+
+const router = useRouter();
+
+const email = ref("");
+const nickname = ref("");
+const password = ref("");
+const passwordConfirm = ref("");
+
+const isSubmitting = ref(false);
+const errorMessage = ref("");
+
+// 닉네임 중복 확인용 상태
+const isCheckingNickname = ref(false);
+const nicknameCheckMessage = ref("");
+const isNicknameDuplicated = ref(null); // null: 아직 모름, true: 중복, false: 사용 가능
+
+// 닉네임이 바뀌면 이전 중복 확인 결과는 무효화
+watch(nickname, () => {
+  isNicknameDuplicated.value = null;
+  nicknameCheckMessage.value = "";
+});
+
+async function handleCheckNickname() {
+  nicknameCheckMessage.value = "";
+  isNicknameDuplicated.value = null;
+
+  const value = nickname.value.trim();
+  if (!value) {
+    nicknameCheckMessage.value = "닉네임을 먼저 입력해주세요.";
+    return;
+  }
+
+  isCheckingNickname.value = true;
+
+  try {
+    //TODO: change this code to actually api code
+    const res = await mockCheckUsernameDuplicate({ username: value });
+
+    const duplicated =
+      res.duplicated ??
+      (typeof res.available === "boolean" ? !res.available : false);
+
+    if (duplicated) {
+      isNicknameDuplicated.value = true;
+      nicknameCheckMessage.value =
+        "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.";
+    } else {
+      isNicknameDuplicated.value = false;
+      nicknameCheckMessage.value = "사용 가능한 닉네임입니다.";
+    }
+
+    //TODO: change upper code to this code for actual API
+    // const res = await checkUsernameDuplicate({ username: value });
+    // const duplicated = res.duplicated; // 응답 형식에 맞게 수정
+  } catch (e) {
+    isNicknameDuplicated.value = null;
+    nicknameCheckMessage.value =
+      "닉네임 중복 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+    console.log(e);
+  } finally {
+    isCheckingNickname.value = false;
+  }
+}
+
+function validate() {
+  errorMessage.value = "";
+
+  if (!email.value.trim() || !nickname.value.trim()) {
+    errorMessage.value = "이메일과 닉네임을 모두 입력해주세요.";
+    return false;
+  }
+
+  if (password.value.length < 8) {
+    errorMessage.value = "비밀번호는 최소 8자 이상이어야 합니다.";
+    return false;
+  }
+
+  if (password.value !== passwordConfirm.value) {
+    errorMessage.value = "비밀번호와 비밀번호 확인이 일치하지 않습니다.";
+    return false;
+  }
+
+  if (isNicknameDuplicated.value === true) {
+    errorMessage.value =
+      "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.";
+    return false;
+  }
+
+  return true;
+}
+
+async function handleSubmit() {
+  if (!validate()) return;
+
+  isSubmitting.value = true;
+  try {
+    // TODO: 1) 지금: mock + ID/PW
+    await mockSignup({
+      email: email.value,
+      nickname: nickname.value,
+      password: password.value,
+    });
+
+    // TODO: 2) 나중: 실제 API
+    // await signupWithIdPw({
+    //   email: email.value,
+    //   nickname: nickname.value,
+    //   password: password.value,
+    // });
+
+    router.push({ name: "Login" });
+  } catch (e) {
+    errorMessage.value = "이미 사용 중인 이메일이거나, 다시 시도해 주세요.";
+    console.log(e); // TODO: remove and apply log
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+function goToLogin() {
+  router.push({ name: "Login" });
+}
+</script>
+
+<template>
+  <div
+    class="min-h-screen bg-gradient-to-b from-yellow-50/70 via-white to-gray-50 text-gray-900 flex flex-col"
+  >
+    <header class="w-full max-w-5xl mx-auto px-4 sm:px-6 pt-6">
+      <h1 class="text-xl font-semibold tracking-tight">BlueStrongMountain</h1>
+    </header>
+
+    <main class="flex-1 flex items-center justify-center px-4 sm:px-6 pb-12">
+      <div
+        class="w-full max-w-md bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-yellow-100/60 px-6 py-8 sm:px-8"
+      >
+        <h2 class="text-2xl font-bold text-gray-900 tracking-tight">
+          회원가입
+        </h2>
+        <p class="mt-2 text-sm text-gray-600">
+          알고리즘 스터디를 함께할 계정을 만들어 주세요.
+        </p>
+
+        <!-- 에러 메시지 -->
+        <p
+          v-if="errorMessage"
+          class="mt-4 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2"
+        >
+          {{ errorMessage }}
+        </p>
+
+        <form
+          class="mt-6 space-y-4"
+          @submit.prevent="handleSubmit"
+        >
+          <div>
+            <label
+              for="signup-email"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              이메일
+            </label>
+            <input
+              id="signup-email"
+              v-model="email"
+              type="email"
+              autocomplete="email"
+              required
+              class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div>
+            <label
+              for="nickname"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              닉네임
+            </label>
+            <div class="flex gap-2">
+              <input
+                id="nickname"
+                v-model="nickname"
+                type="text"
+                autocomplete="nickname"
+                required
+                class="flex-1 rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+                placeholder="스터디에서 사용할 이름"
+              />
+              <button
+                type="button"
+                class="shrink-0 rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
+                :disabled="isCheckingNickname || !nickname.trim()"
+                @click="handleCheckNickname"
+              >
+                <span v-if="!isCheckingNickname">중복 확인</span>
+                <span v-else>확인 중...</span>
+              </button>
+            </div>
+
+            <p
+              v-if="nicknameCheckMessage"
+              class="mt-1 text-xs"
+              :class="
+                isNicknameDuplicated === false
+                  ? 'text-green-600'
+                  : 'text-red-600'
+              "
+            >
+              {{ nicknameCheckMessage }}
+            </p>
+          </div>
+
+          <div>
+            <label
+              for="signup-password"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              비밀번호
+            </label>
+            <input
+              id="signup-password"
+              v-model="password"
+              type="password"
+              autocomplete="new-password"
+              required
+              class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+              placeholder="8자 이상, 안전한 비밀번호"
+            />
+            <p class="mt-1 text-xs text-gray-400">
+              영문, 숫자, 특수문자를 조합하면 더 안전해요.
+            </p>
+          </div>
+
+          <div>
+            <label
+              for="signup-password-confirm"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              비밀번호 확인
+            </label>
+            <input
+              id="signup-password-confirm"
+              v-model="passwordConfirm"
+              type="password"
+              autocomplete="new-password"
+              required
+              class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+              placeholder="비밀번호를 한 번 더 입력해주세요"
+            />
+          </div>
+
+          <button
+            type="submit"
+            :disabled="isSubmitting"
+            class="mt-2 inline-flex w-full items-center justify-center rounded-lg bg-yellow-400 px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            <span v-if="!isSubmitting">가입하기</span>
+            <span v-else>가입 처리 중...</span>
+          </button>
+        </form>
+
+        <div class="mt-6 flex items-center justify-between text-xs sm:text-sm">
+          <button
+            type="button"
+            class="text-gray-500 hover:text-gray-700 underline-offset-2 hover:underline"
+            @click="goToLogin"
+          >
+            이미 계정이 있으신가요?
+          </button>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>

--- a/tests/ForgotPasswordView.spec.js
+++ b/tests/ForgotPasswordView.spec.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const pushMock = vi.fn();
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+import * as mockAuthApi from "../src/api/mockAuthApi";
+import ForgotPasswordView from "../src/views/ForgotPasswordView.vue";
+
+describe("ForgotPasswordView", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("이메일이 비어 있으면 검증 에러를 보여준다", async () => {
+    const wrapper = mount(ForgotPasswordView);
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("가입하신 이메일을 입력해주세요.");
+  });
+
+  it("유효한 이메일 입력 시 mockForgotPassword를 호출하고 안내 메시지를 보여준다", async () => {
+    const forgotSpy = vi
+      .spyOn(mockAuthApi, "mockForgotPassword")
+      .mockResolvedValue({
+        ok: true,
+        token: "reset-token-123",
+      });
+
+    const wrapper = mount(ForgotPasswordView);
+
+    await wrapper.find("#forgot-email").setValue("user@example.com");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(forgotSpy).toHaveBeenCalledWith({
+      email: "user@example.com",
+    });
+
+    expect(wrapper.text()).toContain(
+      "입력하신 이메일로 비밀번호 재설정 안내를 보냈습니다. (이메일이 등록되어 있다면)",
+    );
+
+    // devResetToken이 설정되면 "새 비밀번호 설정하러 가기" 버튼이 렌더링됨
+    expect(wrapper.text()).toContain("새 비밀번호 설정하러 가기");
+  });
+
+  it("개발용 버튼 클릭 시 ResetPassword 라우트로 이동한다", async () => {
+    vi.spyOn(mockAuthApi, "mockForgotPassword").mockResolvedValue({
+      ok: true,
+      token: "reset-token-456",
+    });
+
+    const wrapper = mount(ForgotPasswordView);
+
+    await wrapper.find("#forgot-email").setValue("user@example.com");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    const devButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("새 비밀번호 설정하러 가기"));
+
+    expect(devButton).toBeTruthy();
+
+    await devButton.trigger("click");
+    expect(pushMock).toHaveBeenCalledWith({
+      name: "ResetPassword",
+      query: { token: "reset-token-456" },
+    });
+  });
+});

--- a/tests/LoginView.spec.js
+++ b/tests/LoginView.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// vue-router의 useRouter를 가짜로 만들어서 push만 감시
+const pushMock = vi.fn();
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+// 실제 mockAuthApi를 import 해서 spy만 덮어씌움
+import * as mockAuthApi from "../src/api/mockAuthApi";
+import LoginView from "../src/views/LoginView.vue";
+
+describe("LoginView", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("이메일/비밀번호가 비어 있으면 검증 에러를 보여준다", async () => {
+    const wrapper = mount(LoginView);
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("이메일과 비밀번호를 모두 입력해주세요.");
+  });
+
+  it("유효한 입력 시 mockLogin을 호출하고 GroupList로 이동한다", async () => {
+    const loginSpy = vi.spyOn(mockAuthApi, "mockLogin").mockResolvedValue({
+      user: {
+        id: 1,
+        email: "test@example.com",
+        nickname: "tester",
+      },
+    });
+
+    const wrapper = mount(LoginView);
+
+    await wrapper.find("#email").setValue("test@example.com");
+    await wrapper.find("#password").setValue("password123");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(loginSpy).toHaveBeenCalledWith({
+      email: "test@example.com",
+      password: "password123",
+    });
+    expect(pushMock).toHaveBeenCalledWith({ name: "GroupList" });
+  });
+
+  it("로그인 실패 시 에러 메시지를 보여준다", async () => {
+    vi.spyOn(mockAuthApi, "mockLogin").mockRejectedValue(
+      new Error("로그인 실패"),
+    );
+
+    const wrapper = mount(LoginView);
+
+    await wrapper.find("#email").setValue("test@example.com");
+    await wrapper.find("#password").setValue("password123");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "이메일 또는 비밀번호가 올바르지 않습니다.",
+    );
+  });
+});

--- a/tests/ResetPasswordView.spec.js
+++ b/tests/ResetPasswordView.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// useRoute에서 token을 제공하고, useRouter의 push를 감시
+const pushMock = vi.fn();
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  useRoute: () => ({
+    query: {
+      token: "reset-token-123",
+    },
+  }),
+}));
+
+import * as mockAuthApi from "../src/api/mockAuthApi";
+import ResetPasswordView from "../src/views/ResetPasswordView.vue";
+
+describe("ResetPasswordView", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("비밀번호 길이가 짧으면 검증 에러를 보여준다", async () => {
+    const wrapper = mount(ResetPasswordView);
+
+    await wrapper.find("#new-password").setValue("short");
+    await wrapper.find("#new-password-confirm").setValue("short");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("비밀번호는 최소 8자 이상이어야 합니다.");
+  });
+
+  it("비밀번호와 확인이 다르면 에러를 보여준다", async () => {
+    const wrapper = mount(ResetPasswordView);
+
+    await wrapper.find("#new-password").setValue("password123");
+    await wrapper.find("#new-password-confirm").setValue("different123");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
+    );
+  });
+
+  it("유효한 입력 시 mockResetPassword를 호출하고 성공 메시지를 보여준다", async () => {
+    const resetSpy = vi
+      .spyOn(mockAuthApi, "mockResetPassword")
+      .mockResolvedValue({ ok: true });
+
+    const wrapper = mount(ResetPasswordView);
+
+    await wrapper.find("#new-password").setValue("password123");
+    await wrapper.find("#new-password-confirm").setValue("password123");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(resetSpy).toHaveBeenCalledWith({
+      token: "reset-token-123",
+      newPassword: "password123",
+    });
+
+    expect(wrapper.text()).toContain(
+      "비밀번호가 변경되었습니다. 새 비밀번호로 다시 로그인해 주세요.",
+    );
+  });
+
+  it("mockResetPassword에서 INVALID_OR_EXPIRED_TOKEN 에러가 나면 해당 메시지를 보여준다", async () => {
+    vi.spyOn(mockAuthApi, "mockResetPassword").mockRejectedValue(
+      Object.assign(new Error("유효하지 않거나 만료된 링크입니다."), {
+        code: "INVALID_OR_EXPIRED_TOKEN",
+      }),
+    );
+
+    const wrapper = mount(ResetPasswordView);
+
+    await wrapper.find("#new-password").setValue("password123");
+    await wrapper.find("#new-password-confirm").setValue("password123");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("유효하지 않거나 만료된 링크입니다.");
+  });
+});

--- a/tests/SignupView.spec.js
+++ b/tests/SignupView.spec.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const pushMock = vi.fn();
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+import * as mockAuthApi from "../src/api/mockAuthApi";
+import SignupView from "../src/views/SignupView.vue";
+
+describe("SignupView", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("필수 필드가 비어 있으면 검증 에러를 보여준다", async () => {
+    const wrapper = mount(SignupView);
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("이메일과 닉네임을 모두 입력해주세요.");
+  });
+
+  it("비밀번호와 확인이 다르면 에러를 보여준다", async () => {
+    const wrapper = mount(SignupView);
+
+    await wrapper.find("#signup-email").setValue("user@example.com");
+    await wrapper.find("#nickname").setValue("user");
+    await wrapper.find("#signup-password").setValue("password123");
+    await wrapper.find("#signup-password-confirm").setValue("different123");
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
+    );
+  });
+
+  it("유효한 입력 시 mockSignup 호출 후 Login으로 이동한다", async () => {
+    const signupSpy = vi.spyOn(mockAuthApi, "mockSignup").mockResolvedValue({
+      user: {
+        id: 1,
+        email: "user@example.com",
+        nickname: "user",
+      },
+    });
+
+    const wrapper = mount(SignupView);
+
+    await wrapper.find("#signup-email").setValue("user@example.com");
+    await wrapper.find("#nickname").setValue("user");
+    await wrapper.find("#signup-password").setValue("password123");
+    await wrapper.find("#signup-password-confirm").setValue("password123");
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(signupSpy).toHaveBeenCalledWith({
+      email: "user@example.com",
+      nickname: "user",
+      password: "password123",
+    });
+    expect(pushMock).toHaveBeenCalledWith({ name: "Login" });
+  });
+
+  it("닉네임 중복 확인 버튼 클릭 시 mockCheckUsernameDuplicate를 호출하고 사용 가능 메시지를 보여준다", async () => {
+    const checkSpy = vi
+      .spyOn(mockAuthApi, "mockCheckUsernameDuplicate")
+      .mockResolvedValue({
+        duplicated: false,
+        available: true,
+      });
+
+    const wrapper = mount(SignupView);
+
+    // 닉네임 입력
+    await wrapper.find("#nickname").setValue("uniqueUser");
+
+    // '중복 확인' 버튼 찾기
+    const nicknameCheckButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("중복 확인"));
+
+    expect(nicknameCheckButton).toBeTruthy();
+
+    await nicknameCheckButton.trigger("click");
+    await flushPromises();
+
+    // API가 올바른 파라미터로 호출되었는지
+    expect(checkSpy).toHaveBeenCalledWith({ username: "uniqueUser" });
+
+    // 사용 가능 메시지 노출
+    expect(wrapper.text()).toContain("사용 가능한 닉네임입니다.");
+  });
+
+  it("중복된 닉네임이면 경고 메시지를 보여주고, 제출 시 mockSignup이 호출되지 않는다", async () => {
+    // 닉네임 중복 API: duplicated=true 응답
+    vi.spyOn(mockAuthApi, "mockCheckUsernameDuplicate").mockResolvedValue({
+      duplicated: true,
+      available: false,
+    });
+
+    const signupSpy = vi.spyOn(mockAuthApi, "mockSignup").mockResolvedValue({
+      user: {
+        id: 1,
+        email: "dup@example.com",
+        nickname: "dupUser",
+      },
+    });
+
+    const wrapper = mount(SignupView);
+
+    await wrapper.find("#signup-email").setValue("dup@example.com");
+    await wrapper.find("#nickname").setValue("dupUser");
+
+    // 중복 확인 버튼 클릭
+    const nicknameCheckButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("중복 확인"));
+    expect(nicknameCheckButton).toBeTruthy();
+
+    await nicknameCheckButton.trigger("click");
+    await flushPromises();
+
+    // 중복 경고 메시지 노출
+    expect(wrapper.text()).toContain(
+      "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.",
+    );
+
+    // 비밀번호 입력은 정상적으로
+    await wrapper.find("#signup-password").setValue("password123");
+    await wrapper.find("#signup-password-confirm").setValue("password123");
+
+    // 폼 제출
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    // 중복 상태라면 mockSignup은 호출되지 않아야 한다
+    expect(signupSpy).not.toHaveBeenCalled();
+
+    // 상단 에러 메시지도 닉네임 중복 에러로 보여야 함
+    expect(wrapper.text()).toContain(
+      "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.",
+    );
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,11 @@ import vue from "@vitejs/plugin-vue";
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      "@": "/src",
+    },
+  },
   css: {
     preprocessorOptions: {
       scss: {


### PR DESCRIPTION
이슈번호 : https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/10

---

## ✅ 이 PR에서 구현한 내용

### 1) 회원가입(Signup) 플로우

* 이메일 / 닉네임 / 비밀번호 입력 폼 구성
* 필수 필드 검증

  * 하나라도 비어 있으면 에러 메시지 노출
* `mockSignup` API 연동
* 회원가입 성공 시 → 로그인 페이지로 이동

---

### 2) 로그인(Login) 플로우

* 이메일 / 비밀번호 입력 폼 구현
* 필수 값 검증 후 `mockLogin` 호출
* 로그인 성공 시:

  * Auth 상태 업데이트 (user, 토큰 등)
  * 그룹 목록 페이지(`/groups`)로 이동
* 인증 실패 시 에러 메시지 표시

---

### 3) 비밀번호 찾기 플로우

* **이메일 기반 비밀번호 찾기 화면** 추가

  * 이메일만 입력하는 간단한 폼
  * 입력값 미기재 시 검증 에러 출력
* `mockForgotPassword` (또는 이에 상응하는 mock API) 연동
* 제출 후:

  * “비밀번호 재설정 메일을 전송했다”는 안내 메시지 노출
  * 실제 메일 전송은 없지만, 이후 resetpw 화면 진입까지의 **UX 흐름**을 미리 설계

---

### 4) 비밀번호 재설정 플로우

* **새 비밀번호 / 비밀번호 확인 입력 폼** 구현
* 비밀번호 일치 여부 및 필수값 검증
* URL 파라미터(토큰 또는 이메일 등)를 통해 요청 유효성 가정
* `mockResetPassword` 호출 후:

  * 성공 시 → 로그인 페이지로 리다이렉트
  * 실패 시 에러 메시지 출력

---

### 5) Auth 상태 관리(useAuth) 정리

* 전역 상태

  * `user`, `accessToken`, `refreshToken`, `status`, `error` 등 구성
* `login / logout` 유틸 함수 구현
* LocalStorage 연동 함수(`saveToStorage`)로

  * 새로고침 후에도 로그인 상태 유지 가능하게 구조화
* 추후 실제 JWT 기반 인증으로 전환해도 최소 변경으로 확장 가능하도록 설계

---

### 6) 라우터 연동

* 로그인/회원가입/비밀번호 찾기/비밀번호 재설정 라우트 등록

  * 예: `/login`, `/signup`, `/forgot-password`, `/reset-password` (실제 path/route name에 맞게 구성)
* 화면 간 이동 플로우:

  * 회원가입 완료 → `/login`
  * 로그인 성공 → `/groups`
  * “비밀번호 찾기” 링크 클릭 → `/forgot-password`
  * 메일 링크(가정) → `/reset-password`로 진입

---

## 📂 변경된 주요 컴포넌트/모듈

* `src/views/LoginView.vue`

  * 로그인 폼 UI 및 검증, 로그인 성공 시 라우팅

* `src/views/SignupView.vue`

  * 회원가입 폼 UI, 필수값 검증, 가입 성공 후 로그인 페이지로 이동

* `src/views/ForgotPasswordView.vue`

  * 이메일 입력 기반 비밀번호 찾기 화면
  * 전송 후 안내 메시지 노출

* `src/views/ResetPasswordView.vue`

  * 새 비밀번호 설정 폼
  * 재설정 성공 시 로그인 페이지로 이동

* `src/api/mockAuthApi.js`

  * `mockSignup`, `mockLogin`에 더해
  * `mockForgotPassword`, `mockResetPassword` 등 비밀번호 찾기/재설정용 mock 함수 추가

* `src/composables/useAuth.js`

  * Auth 전역 상태 및 저장/초기화 로직 구현

* `src/router/index.js`

  * `/login`, `/signup`, `/forgot-password`, `/reset-password` 라우트 등록 및 네비게이션 플로우 구성

---

## 🧪 동작 흐름 / 사용자 시나리오

1. **회원가입**

   * `/signup` 진입 → 이메일/닉네임/비밀번호 입력 → 가입
   * 성공 시 `/login`으로 이동

2. **로그인**

   * `/login`에서 이메일/비밀번호 입력 후 로그인
   * 성공 시 `/groups`(그룹 목록)으로 이동

3. **비밀번호 찾기**

   * 로그인 화면에서 “비밀번호를 잊으셨나요?” 클릭 → `/forgot-password`
   * 이메일 입력 후 전송 → 안내 메시지 표시

4. **비밀번호 재설정**

   * (메일 링크를 탔다고 가정하고) `/reset-password` 진입
   * 새 비밀번호/확인 입력 → 재설정 성공 시 `/login`으로 이동

---

## 💡 기타

* 현재는 **mock 기반 Auth**이지만,
  실제 백엔드 API만 붙이면 **실서비스용 Auth 플로우로 확장 가능한 구조**로 설계됨.
* Signup/Login뿐 아니라 ForgotPw/ResetPw까지 한 번에 묶어서
  **신규 사용자 온보딩부터 계정 복구까지의 기본 Auth UX**를 한 사이클 완성.

---
