### PR TITLE
[BST-18] 보드 상세 현황 뷰 & 보드 유저 상태 API 연동

### DIFF
--- a/src/api/boardApi.js
+++ b/src/api/boardApi.js
@@ -1,0 +1,20 @@
+import httpClient from "./httpClient";
+
+// 방금 만든 목업 API
+import { mockGetBoardUserStatus } from "./mockBoardUserStatusApi";
+
+// 나중에 .env로 빼면 더 좋음
+const USE_MOCK = true;
+
+export async function getBoardUserStatus(groupId, boardId) {
+  if (USE_MOCK) {
+    // ✅ 지금은 목업 데이터 반환
+    return mockGetBoardUserStatus(groupId, boardId);
+  }
+
+  // 🔜 실제 백엔드 붙일 때는 여기만 살리면 됨
+  const res = await httpClient.get(
+    `/api/v1/groups/${groupId}/boards/${boardId}/userStatus`,
+  );
+  return res.data;
+}

--- a/src/api/mockBoardUserStatusApi.js
+++ b/src/api/mockBoardUserStatusApi.js
@@ -1,0 +1,320 @@
+// 보드별 유저 풀이 현황 mock
+// key: `${groupId}:${boardId}`
+//
+// 그룹 구조 참고
+// Group 1: owner = 1764919478917, managers = [1, 1764919478917], members = [2,3,4,5]
+// Group 2: owner = 2, managers = [2], members = [3,4,5,1764919478917]
+// Group 3: owner = 3, managers = [3,1764919478917], members = [4,5,6,7,8]
+
+const MOCK_STATUS_BY_BOARD = {
+  // ======================
+  // Group 1 - Board 1
+  // Vue.js 프론트엔드 뽀개기
+  // problems: [1409, 1508, 1000]
+  // 참여 유저(예시): 1764919478917(소유자), 1,2,3,4,5
+  // ======================
+  "1:1": {
+    problemStatus: [
+      {
+        problemId: 1409,
+        solvedUsers: [1, 3, 1764919478917], // 김청강, 달피곰, 소유자
+      },
+      {
+        problemId: 1508,
+        solvedUsers: [1, 5], // 김청강, 정프론트, 카카카
+      },
+      {
+        problemId: 1000,
+        solvedUsers: [2, 3], // 이알고, 달피곰, 카카카
+      },
+    ],
+    userStatus: [
+      {
+        userId: 1764919478917, // 현재 로그인 유저(가정)
+        solvedProblems: [1409],
+      },
+      {
+        userId: 1,
+        solvedProblems: [1409, 1508],
+      },
+      {
+        userId: 2,
+        solvedProblems: [1000],
+      },
+      {
+        userId: 3,
+        solvedProblems: [1409, 1000],
+      },
+      {
+        userId: 4,
+        solvedProblems: [],
+      },
+      {
+        userId: 5,
+        solvedProblems: [1508],
+      },
+    ],
+  },
+
+  // ======================
+  // Group 1 - Board 2
+  // 알고리즘 코딩테스트 대비반
+  // problems: [1001, 1002, 1003, 1004]
+  // 동일 유저풀이 구조 + 카카카/소유자 포함
+  // ======================
+  "1:2": {
+    problemStatus: [
+      {
+        problemId: 1001,
+        solvedUsers: [1, 3, 5],
+      },
+      {
+        problemId: 1002,
+        solvedUsers: [1, 2, 5],
+      },
+      {
+        problemId: 1003,
+        solvedUsers: [2, 5],
+      },
+      {
+        problemId: 1004,
+        solvedUsers: [3, 1764919478917],
+      },
+    ],
+    userStatus: [
+      {
+        userId: 1764919478917,
+        solvedProblems: [1004],
+      },
+      {
+        userId: 1,
+        solvedProblems: [1001, 1002],
+      },
+      {
+        userId: 2,
+        solvedProblems: [1002, 1003],
+      },
+      {
+        userId: 3,
+        solvedProblems: [1001, 1004],
+      },
+      {
+        userId: 4,
+        solvedProblems: [],
+      },
+      {
+        userId: 5,
+        solvedProblems: [1001, 1002, 1003],
+      },
+    ],
+  },
+
+  // ======================
+  // Group 1 - Board 7
+  // 리액트 vs 뷰 비교 분석
+  // problems: [2004, ...] 라고 가정하고 2004만 사용
+  // ======================
+  "1:7": {
+    problemStatus: [
+      {
+        problemId: 2004,
+        solvedUsers: [1, 2, 5, 1764919478917],
+      },
+    ],
+    userStatus: [
+      {
+        userId: 1764919478917,
+        solvedProblems: [2004],
+      },
+      {
+        userId: 1,
+        solvedProblems: [2004],
+      },
+      {
+        userId: 2,
+        solvedProblems: [2004],
+      },
+      {
+        userId: 3,
+        solvedProblems: [],
+      },
+      {
+        userId: 4,
+        solvedProblems: [],
+      },
+      {
+        userId: 5,
+        solvedProblems: [2004],
+      },
+    ],
+  },
+
+  // ======================
+  // Group 2 - Board 3
+  // 자유 주제 아이디어 보드
+  // problems: [1005, 1006, 1007]
+  // 그룹 2 참여자: 2(소유자),3,4,5,1764919478917
+  // 여기에 카카카도 끼워서 테스트용으로 포함
+  // ======================
+  "2:3": {
+    problemStatus: [
+      {
+        problemId: 1005,
+        solvedUsers: [2, 3],
+      },
+      {
+        problemId: 1006,
+        solvedUsers: [3, 4],
+      },
+      {
+        problemId: 1007,
+        solvedUsers: [4, 5, 1764919478917],
+      },
+    ],
+    userStatus: [
+      {
+        userId: 2,
+        solvedProblems: [1005],
+      },
+      {
+        userId: 3,
+        solvedProblems: [1005, 1006],
+      },
+      {
+        userId: 4,
+        solvedProblems: [1006, 1007],
+      },
+      {
+        userId: 5,
+        solvedProblems: [1007],
+      },
+      {
+        userId: 1764919478917,
+        solvedProblems: [1007],
+      },
+    ],
+  },
+
+  // ======================
+  // Group 2 - Board 4
+  // 2023년 상반기 회고
+  // problems: [1008, 1009]
+  // ======================
+  "2:4": {
+    problemStatus: [
+      {
+        problemId: 1009,
+        solvedUsers: [3, 4, 1764919478917],
+      },
+    ],
+    userStatus: [
+      {
+        userId: 2,
+        solvedProblems: [1008],
+      },
+      {
+        userId: 3,
+        solvedProblems: [1009],
+      },
+      {
+        userId: 4,
+        solvedProblems: [1008, 1009],
+      },
+      {
+        userId: 5,
+        solvedProblems: [],
+      },
+      {
+        userId: 1764919478917,
+        solvedProblems: [1009],
+      },
+    ],
+  },
+
+  // ======================
+  // Group 3 - Board 5
+  // 지난주 CS 스터디 (네트워크)
+  // problems: [2000]
+  // 그룹 3 참여자: 3(소유자), 4,5,6,7,8, 1764919478917(매니저)
+  // + 카카카 포함
+  // ======================
+  "3:5": {
+    problemStatus: [
+      {
+        problemId: 2000,
+        solvedUsers: [3, 4, 5, 6, 1764919478917],
+      },
+    ],
+    userStatus: [
+      {
+        userId: 3,
+        solvedProblems: [2000],
+      },
+      {
+        userId: 4,
+        solvedProblems: [2000],
+      },
+      {
+        userId: 5,
+        solvedProblems: [2000],
+      },
+      {
+        userId: 6,
+        solvedProblems: [2000],
+      },
+      {
+        userId: 7,
+        solvedProblems: [],
+      },
+      {
+        userId: 8,
+        solvedProblems: [],
+      },
+      {
+        userId: 1764919478917,
+        solvedProblems: [2000],
+      },
+    ],
+  },
+
+  // ======================
+  // Group 3 - Board 6
+  // 사내 해커톤 프로젝트 (문제 없음)
+  // ======================
+  "3:6": {
+    problemStatus: [],
+    userStatus: [
+      { userId: 3, solvedProblems: [] },
+      { userId: 4, solvedProblems: [] },
+      { userId: 5, solvedProblems: [] },
+      { userId: 6, solvedProblems: [] },
+      { userId: 7, solvedProblems: [] },
+      { userId: 8, solvedProblems: [] },
+      { userId: 1764919478917, solvedProblems: [] },
+      { userId: 1764863505459, solvedProblems: [] },
+    ],
+  },
+};
+
+// 기본 fallback (보드/그룹 매칭 안 될 때)
+const DEFAULT_STATUS = {
+  problemStatus: [],
+  userStatus: [],
+};
+
+// 실제 mock 함수
+export async function mockGetBoardUserStatus(groupId, boardId) {
+  const key = `${Number(groupId)}:${Number(boardId)}`;
+  console.log("[Mock] getBoardUserStatus called:", { key });
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const data = MOCK_STATUS_BY_BOARD[key] || DEFAULT_STATUS;
+      resolve({
+        boardId: Number(boardId),
+        problemStatus: data.problemStatus,
+        userStatus: data.userStatus,
+      });
+    }, 300); // 약간의 딜레이
+  });
+}

--- a/src/components/BoardList.vue
+++ b/src/components/BoardList.vue
@@ -82,6 +82,20 @@ function goEditBoard(id) {
   });
 }
 
+function goBoardDetail(id) {
+  router.push({
+    name: "BoardDetail",
+    params: {
+      groupId: route.params.groupId,
+      boardId: id,
+    },
+  });
+}
+
+function goGroupList() {
+  router.push({ name: "GroupList" });
+}
+
 async function handleDelete(id) {
   if (confirm("정말 이 보드를 삭제하시겠습니까?")) {
     deleteBoard(id);
@@ -92,6 +106,13 @@ async function handleDelete(id) {
 
 <template>
   <div class="p-4 max-w-3xl mx-auto">
+    <button
+      type="button"
+      class="mb-2 inline-flex items-center text-[11px] text-gray-400 hover:text-gray-600"
+      @click="goGroupList"
+    >
+      ← 보드 목록으로
+    </button>
     <div class="flex flex-col sm:flex-row justify-between gap-3 mb-6">
       <div class="relative flex-1">
         <div
@@ -193,44 +214,51 @@ async function handleDelete(id) {
       <li
         v-for="board in currentDisplayBoards"
         :key="board.id"
-        class="group flex justify-between items-start border rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow"
+        class="group flex justify-between items-center border rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow"
       >
-        <div class="flex-1 min-w-0 mr-4">
-          <div class="font-semibold text-gray-900 truncate text-base">
-            {{ board.title }}
-          </div>
-          <div class="mt-1.5 flex items-center text-xs text-gray-500 space-x-2">
-            <span
-              class="px-2 py-0.5 rounded"
-              :class="
-                currentTab === 'active'
-                  ? 'bg-green-100 text-green-800'
-                  : 'bg-red-100 text-red-800'
-              "
+        <button
+          type="button"
+          class="flex justify-between items-start w-full text-left"
+          @click="goBoardDetail(board.id)"
+        >
+          <div class="flex-1 min-w-0 mr-4">
+            <div class="font-semibold text-gray-900 truncate text-base">
+              {{ board.title }}
+            </div>
+            <div
+              class="mt-1.5 flex items-center text-xs text-gray-500 space-x-2"
             >
-              {{ currentTab === "active" ? "진행중" : "마감됨" }}
-            </span>
-            <span>
-              마감: {{ board.deadline ? board.deadline : "설정 안 함" }}
-            </span>
-            <span>·</span>
-            <span>문제 {{ board.problemsCount || 0 }}개</span>
+              <span
+                class="px-2 py-0.5 rounded"
+                :class="
+                  currentTab === 'active'
+                    ? 'bg-green-100 text-green-800'
+                    : 'bg-red-100 text-red-800'
+                "
+              >
+                {{ currentTab === "active" ? "진행중" : "마감됨" }}
+              </span>
+              <span>
+                마감: {{ board.deadline ? board.deadline : "설정 안 함" }}
+              </span>
+              <span>·</span>
+              <span>문제 {{ board.problemsCount || 0 }}개</span>
+            </div>
           </div>
-        </div>
-
+        </button>
         <div
           v-if="canManageBoards"
-          class="flex items-center space-x-2 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity"
+          class="flex flex-row items-center self-center gap-2 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity"
         >
           <button
             v-if="!isExpired(board.deadline)"
-            class="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-offset-2 focus:ring-gray-200"
+            class="px-3 py-1.5 text-xs font-medium whitespace-nowrap text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-offset-2 focus:ring-gray-200"
             @click.stop="goEditBoard(board.id)"
           >
             수정
           </button>
           <button
-            class="px-3 py-1.5 text-xs font-medium text-white bg-red-500 border border-red-500 rounded-lg hover:bg-red-600 focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+            class="px-3 py-1.5 text-xs font-medium whitespace-nowrap text-white bg-red-500 border border-red-500 rounded-lg hover:bg-red-600 focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
             @click.stop="handleDelete(board.id)"
           >
             삭제

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ import ForgotPasswordView from "../views/ForgotPasswordView.vue";
 import ResetPasswordView from "../views/ResetPasswordView.vue";
 
 import MyPageView from "../views/MyPageView.vue";
+import BoardDetailView from "../views/BoardDetailView.vue";
 
 import { fetchGroupById } from "@/data/groupStore";
 import { useAuthStore } from "@/data/authStore";
@@ -85,6 +86,12 @@ const routes = [
     name: "BoardCreate",
     component: ProblemBoard,
     meta: { requiresAuth: true, requiresGroupManager: true },
+  },
+  {
+    path: "/groups/:groupId/boards/:boardId",
+    name: "BoardDetail",
+    component: BoardDetailView,
+    meta: { requiresAuth: true, requiresGroupMember: true },
   },
   {
     path: "/groups/:groupId/boards/:boardId/edit",

--- a/src/views/BoardDetailView.vue
+++ b/src/views/BoardDetailView.vue
@@ -1,0 +1,485 @@
+<script setup>
+import { ref, computed, onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useAuthStore } from "../data/authStore";
+import { fetchBoardById } from "../data/boardStore";
+import { fetchGroupById } from "../data/groupStore";
+import { members } from "../data/memberStore";
+import { getBoardUserStatus } from "../api/boardApi";
+
+const route = useRoute();
+const router = useRouter();
+const authStore = useAuthStore();
+
+const board = ref(null);
+const group = ref(null);
+const status = ref(null); // { problemStatus: [], userStatus: [] }
+
+const loading = ref(true);
+const error = ref("");
+
+const viewMode = ref("problem"); // "problem" | "user"
+const focusOnMe = ref(false); // 내 현황만 보기
+
+const currentUserId = computed(() => authStore.user.value?.id ?? null);
+
+// ===== 공통 유틸 =====
+function toNumber(v) {
+  const n = Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+// 그룹 참여자 목록 (owner + managers + members)
+const participants = computed(() => {
+  if (!group.value) return [];
+
+  const idSet = new Set();
+
+  if (group.value.ownerId != null) {
+    idSet.add(toNumber(group.value.ownerId));
+  }
+  (group.value.managerIds || []).forEach((id) => idSet.add(toNumber(id)));
+  (group.value.memberIds || []).forEach((id) => idSet.add(toNumber(id)));
+
+  // memberStore에 있는 유저 데이터에서 필터
+  return members.value.filter((m) => idSet.has(toNumber(m.id)));
+});
+
+// focusOnMe 토글을 적용한 사용자 목록
+const displayUsers = computed(() => {
+  if (!participants.value.length) return [];
+  if (focusOnMe.value && currentUserId.value) {
+    const uid = toNumber(currentUserId.value);
+    return participants.value.filter((u) => toNumber(u.id) === uid);
+  }
+  return participants.value;
+});
+
+// 보드의 문제 목록
+const boardProblems = computed(() =>
+  (board.value?.problems || []).filter(
+    (p) => p && p.id !== undefined && p.id !== null,
+  ),
+);
+
+// 문제 ID -> solvedUsers(Set) 매핑
+const problemSolvedMap = computed(() => {
+  const map = new Map();
+  if (!status.value?.problemStatus) return map;
+
+  status.value.problemStatus.forEach((p) => {
+    const set = new Set((p.solvedUsers || []).map(toNumber));
+    map.set(toNumber(p.problemId), set);
+  });
+
+  return map;
+});
+
+// userId -> solvedProblems(Set) 매핑
+const userSolvedMap = computed(() => {
+  const map = new Map();
+  if (!status.value?.userStatus) return map;
+
+  status.value.userStatus.forEach((u) => {
+    const set = new Set((u.solvedProblems || []).map(toNumber));
+    map.set(toNumber(u.userId), set);
+  });
+
+  return map;
+});
+
+function isSolvedByUser(problemId, userId) {
+  const pId = toNumber(problemId);
+  const uId = toNumber(userId);
+  const solvedSet = problemSolvedMap.value.get(pId);
+  return solvedSet ? solvedSet.has(uId) : false;
+}
+
+const totalProblems = computed(() => boardProblems.value.length);
+const totalParticipants = computed(() => participants.value.length);
+
+// 전체 평균 완료율 (문제 기준)
+const avgCompletionRate = computed(() => {
+  if (!totalProblems.value || !totalParticipants.value) return 0;
+
+  let solvedCount = 0;
+  boardProblems.value.forEach((problem) => {
+    if (!problem || problem.id == null) return;
+    const pId = toNumber(problem.id);
+    if (pId == null) return;
+
+    const set = problemSolvedMap.value.get(pId);
+    if (set) solvedCount += set.size;
+  });
+
+  const totalSlots = totalProblems.value * totalParticipants.value;
+  return totalSlots ? Math.round((solvedCount / totalSlots) * 100) : 0;
+});
+
+// 현재 유저의 완료율
+const myCompletionRate = computed(() => {
+  if (!currentUserId.value || !totalProblems.value) return 0;
+  const mySet = userSolvedMap.value.get(toNumber(currentUserId.value));
+  if (!mySet) return 0;
+  let solved = 0;
+  boardProblems.value.forEach((p) => {
+    if (mySet.has(toNumber(p.id))) solved += 1;
+  });
+  return Math.round((solved / totalProblems.value) * 100);
+});
+
+// 로딩
+onMounted(async () => {
+  loading.value = true;
+  error.value = "";
+
+  try {
+    const groupId = route.params.groupId;
+    const boardId = route.params.boardId;
+
+    const [g, b, s] = await Promise.all([
+      fetchGroupById(groupId),
+      fetchBoardById(boardId),
+      getBoardUserStatus(groupId, boardId),
+    ]);
+
+    group.value = g;
+    board.value = b;
+    status.value = s;
+  } catch (e) {
+    console.error(e);
+    error.value = "보드 정보를 불러오는 중 오류가 발생했습니다.";
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-50">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+      <!-- 상단: 헤더 -->
+      <div class="flex items-start justify-between gap-4 mb-6">
+        <div>
+          <button
+            type="button"
+            class="mb-2 inline-flex items-center text-[11px] text-gray-400 hover:text-gray-600"
+            @click="
+              router.push({
+                name: 'BoardList',
+                params: { groupId: route.params.groupId },
+              })
+            "
+          >
+            ← 보드 목록으로
+          </button>
+
+          <h1 class="text-xl sm:text-2xl font-bold text-gray-900">
+            {{ board?.title || "보드 상세" }}
+          </h1>
+          <p class="mt-1 text-xs sm:text-sm text-gray-500">
+            {{ group?.name || "스터디 그룹" }}
+          </p>
+
+          <div class="mt-2 flex flex-wrap gap-2 text-[11px] sm:text-xs">
+            <span
+              class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 font-medium text-yellow-800 border border-yellow-200"
+            >
+              📌 문제 {{ totalProblems }}개
+            </span>
+            <span
+              class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-700 border border-gray-200"
+            >
+              👥 참여 {{ totalParticipants }}명
+            </span>
+            <span
+              v-if="board?.deadline"
+              class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-medium text-blue-800 border border-blue-200"
+            >
+              ⏰ 마감 {{ board.deadline }}
+            </span>
+          </div>
+        </div>
+
+        <!-- 오른쪽: 요약 배지 -->
+        <div class="space-y-2 text-right text-[11px] sm:text-xs">
+          <!-- 전체 평균 완료율 -->
+          <div
+            class="inline-flex w-28 sm:w-32 flex-col items-center rounded-xl bg-white border border-gray-100 shadow-sm px-3 py-2 text-center"
+          >
+            <span class="text-[10px] text-gray-400">전체 평균 완료율</span>
+            <span class="text-lg font-bold text-yellow-600">
+              {{ avgCompletionRate }}%
+            </span>
+          </div>
+
+          <!-- 내 완료율 -->
+          <div
+            v-if="currentUserId"
+            class="inline-flex w-28 sm:w-32 flex-col items-center rounded-xl bg-yellow-400 border border-yellow-300 shadow-sm px-3 py-2 text-center text-gray-900"
+          >
+            <span class="text-[10px] text-gray-700">내 완료율</span>
+            <span class="text-lg font-bold"> {{ myCompletionRate }}% </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 로딩 / 에러 -->
+      <div
+        v-if="loading"
+        class="py-10 text-center text-sm text-gray-500"
+      >
+        데이터를 불러오는 중입니다...
+      </div>
+      <div
+        v-else-if="error"
+        class="py-10 text-center text-sm text-red-500"
+      >
+        {{ error }}
+      </div>
+
+      <template v-else>
+        <!-- 모드 토글 + 내 현황만 보기 -->
+        <div
+          class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-4"
+        >
+          <div class="inline-flex rounded-full bg-gray-100 p-1">
+            <button
+              type="button"
+              class="px-3 py-1.5 rounded-full text-xs font-semibold"
+              :class="
+                viewMode === 'problem'
+                  ? 'bg-yellow-400 text-white shadow'
+                  : 'text-gray-600'
+              "
+              @click="viewMode = 'problem'"
+            >
+              문제 기준 보기
+            </button>
+            <button
+              type="button"
+              class="px-3 py-1.5 rounded-full text-xs font-semibold"
+              :class="
+                viewMode === 'user'
+                  ? 'bg-yellow-400 text-white shadow'
+                  : 'text-gray-600'
+              "
+              @click="viewMode = 'user'"
+            >
+              사용자 기준 보기
+            </button>
+          </div>
+
+          <label
+            class="inline-flex items-center gap-2 text-[11px] sm:text-xs text-gray-600"
+          >
+            <input
+              v-model="focusOnMe"
+              type="checkbox"
+              class="rounded border-gray-300 text-yellow-500 focus:ring-yellow-500"
+              :disabled="!currentUserId"
+            />
+            <span>
+              내 현황만 보기
+              <span
+                v-if="!currentUserId"
+                class="text-gray-400"
+              >
+                (로그인 필요)
+              </span>
+            </span>
+          </label>
+        </div>
+
+        <!-- 1) 문제 기준 보기: 문제 x 사용자 매트릭스 -->
+        <section
+          v-if="viewMode === 'problem'"
+          class="mt-3"
+        >
+          <div
+            class="mb-2 text-[11px] text-gray-500 flex items-center justify-between"
+          >
+            <span>
+              각 문제별로 누가 풀었는지 한눈에 볼 수 있어요. (체크 ✅ 는 풀이
+              완료)
+            </span>
+          </div>
+
+          <div
+            class="overflow-x-auto rounded-xl border border-gray-200 bg-white"
+          >
+            <table class="min-w-full text-xs">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th
+                    class="sticky left-0 z-10 bg-gray-50 px-3 py-2 text-left text-[11px] font-semibold text-gray-700 border-b border-r border-gray-200"
+                  >
+                    문제
+                  </th>
+                  <th
+                    v-for="user in displayUsers"
+                    :key="user.id"
+                    class="px-3 py-2 text-[11px] font-semibold text-gray-700 border-b border-gray-200 whitespace-nowrap"
+                    :class="
+                      currentUserId && Number(user.id) === Number(currentUserId)
+                        ? 'bg-yellow-50'
+                        : ''
+                    "
+                  >
+                    {{ user.name }}
+                    <span class="text-[10px] text-gray-400">
+                      (@{{ user.nickname }})
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="problem in boardProblems"
+                  :key="problem.id"
+                  class="border-t border-gray-100"
+                >
+                  <!-- 문제 정보 -->
+                  <td
+                    class="sticky left-0 z-10 bg-white/95 px-3 py-2 text-[11px] border-r border-gray-100"
+                  >
+                    <div class="font-medium text-gray-900">
+                      {{ problem.title || problem.titleKo || `#${problem.id}` }}
+                    </div>
+                    <div class="text-[10px] text-gray-500">
+                      ID: {{ problem.id }}
+                    </div>
+                    <div class="text-[10px] text-gray-400 mt-0.5">
+                      {{
+                        (problemSolvedMap.get(problem.id)?.size || 0) +
+                        " / " +
+                        totalParticipants +
+                        " 명 해결"
+                      }}
+                    </div>
+                  </td>
+
+                  <!-- 사용자별 풀이 여부 -->
+                  <td
+                    v-for="user in displayUsers"
+                    :key="user.id"
+                    class="px-3 py-2 text-center align-middle"
+                    :class="
+                      currentUserId && Number(user.id) === Number(currentUserId)
+                        ? 'bg-yellow-50/80'
+                        : ''
+                    "
+                  >
+                    <span
+                      v-if="isSolvedByUser(problem.id, user.id)"
+                      class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-green-100 text-[12px] text-green-800 border border-green-200"
+                    >
+                      ✅
+                    </span>
+                    <span
+                      v-else
+                      class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-50 text-[11px] text-gray-400 border border-dashed border-gray-200"
+                    >
+                      ···
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- 2) 사용자 기준 보기: 사용자 카드 + 문제 체크리스트 -->
+        <section
+          v-else
+          class="mt-4"
+        >
+          <p class="mb-3 text-[11px] text-gray-500">
+            각 사용자별로 이번 보드에서 어떤 문제를 풀었는지 확인할 수 있습니다.
+          </p>
+
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div
+              v-for="user in displayUsers"
+              :key="user.id"
+              class="rounded-2xl border border-gray-200 bg-white shadow-sm p-4"
+              :class="
+                currentUserId && Number(user.id) === Number(currentUserId)
+                  ? 'ring-1 ring-yellow-400'
+                  : ''
+              "
+            >
+              <div class="flex items-center justify-between mb-3">
+                <div>
+                  <p class="text-sm font-semibold text-gray-900">
+                    {{ user.name }}
+                  </p>
+                  <p class="text-[11px] text-gray-500">@{{ user.nickname }}</p>
+                </div>
+
+                <div class="text-right">
+                  <p class="text-[10px] text-gray-400 mb-0.5">완료율</p>
+                  <p class="text-sm font-bold text-yellow-600">
+                    {{
+                      (() => {
+                        const solvedSet =
+                          userSolvedMap.get(toNumber(user.id)) || new Set();
+                        const solvedCount = boardProblems.filter((p) =>
+                          solvedSet.has(toNumber(p.id)),
+                        ).length;
+                        return totalProblems
+                          ? Math.round((solvedCount / totalProblems) * 100)
+                          : 0;
+                      })()
+                    }}%
+                  </p>
+                </div>
+              </div>
+
+              <div class="space-y-1 max-h-40 overflow-y-auto pr-1">
+                <div
+                  v-for="problem in boardProblems"
+                  :key="problem.id"
+                  class="flex items-center justify-between rounded-lg px-2 py-1.5 text-[11px]"
+                  :class="
+                    isSolvedByUser(problem.id, user.id)
+                      ? 'bg-green-50 border border-green-100'
+                      : 'bg-gray-50 border border-gray-100'
+                  "
+                >
+                  <div class="min-w-0">
+                    <p
+                      class="truncate font-medium"
+                      :class="
+                        isSolvedByUser(problem.id, user.id)
+                          ? 'text-gray-900'
+                          : 'text-gray-600'
+                      "
+                    >
+                      {{ problem.title || problem.titleKo || `#${problem.id}` }}
+                    </p>
+                    <p class="text-[10px] text-gray-400">
+                      ID: {{ problem.id }}
+                    </p>
+                  </div>
+                  <span
+                    v-if="isSolvedByUser(problem.id, user.id)"
+                    class="ml-2 inline-flex items-center justify-center w-6 h-6 rounded-full bg-green-100 text-[11px] text-green-700 border border-green-200"
+                  >
+                    ✔
+                  </span>
+                  <span
+                    v-else
+                    class="ml-2 inline-flex items-center justify-center w-6 h-6 rounded-full bg-white text-[11px] text-gray-300 border border-gray-200"
+                  >
+                    …
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </template>
+    </div>
+  </div>
+</template>

--- a/tests/BoardDetailView.spec.js
+++ b/tests/BoardDetailView.spec.js
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref, nextTick } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// =======================
+// 1) vue-router mock
+// =======================
+const pushMock = vi.fn();
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({
+    params: {
+      groupId: 1,
+      boardId: 10,
+    },
+  }),
+}));
+
+// =======================
+// 2) authStore mock
+// =======================
+vi.mock("@/data/authStore", () => {
+  const user = ref({
+    id: 1,
+    name: "이알고",
+    nickname: "algoLee",
+  });
+
+  return {
+    useAuthStore: () => ({ user }),
+  };
+});
+
+// =======================
+// 3) memberStore mock
+// =======================
+vi.mock("@/data/memberStore", () => {
+  const members = ref([
+    { id: 1, name: "이알고", nickname: "algoLee" },
+    { id: 2, name: "달피곰", nickname: "baekjoonPark" },
+    { id: 3, name: "집에갈까요", nickname: "campChoi" },
+  ]);
+
+  return { members };
+});
+
+// =======================
+// 4) groupStore mock
+// =======================
+vi.mock("@/data/groupStore", () => {
+  const fetchGroupById = vi.fn();
+  return { fetchGroupById };
+});
+
+// =======================
+// 5) boardStore mock
+// =======================
+vi.mock("@/data/boardStore", () => {
+  const fetchBoardById = vi.fn();
+  return { fetchBoardById };
+});
+
+// =======================
+// 6) boardApi mock
+// =======================
+vi.mock("@/api/boardApi", () => {
+  const getBoardUserStatus = vi.fn();
+  return { getBoardUserStatus };
+});
+
+// =======================
+// 7) SUT & mocks import
+// =======================
+import BoardDetailView from "@/views/BoardDetailView.vue";
+import { useAuthStore as useAuthStoreMock } from "@/data/authStore";
+import { members as membersRef } from "@/data/memberStore";
+import { fetchGroupById as fetchGroupByIdMock } from "@/data/groupStore";
+import { fetchBoardById as fetchBoardByIdMock } from "@/data/boardStore";
+import { getBoardUserStatus as getBoardUserStatusMock } from "@/api/boardApi";
+
+// 공통 더미 데이터
+const sampleGroup = {
+  id: 1,
+  name: "CS 면접 대비반",
+  ownerId: 1,
+  managerIds: [1],
+  memberIds: [1, 2, 3],
+};
+
+const sampleBoard = {
+  id: 10,
+  title: "2023년 상반기 회고",
+  deadline: "2099-12-31",
+  problems: [
+    { id: 1008, title: "A@B" },
+    { id: 1009, title: "A#B" },
+  ],
+};
+
+const sampleStatus = {
+  problemStatus: [
+    { problemId: 1008, solvedUsers: [1, 2] },
+    { problemId: 1009, solvedUsers: [1, 3] },
+  ],
+  userStatus: [
+    { userId: 1, solvedProblems: [1008, 1009] },
+    { userId: 2, solvedProblems: [1008] },
+    { userId: 3, solvedProblems: [1009] },
+  ],
+};
+
+// 공통 성공 mock 세팅
+function setupSuccessMocks() {
+  fetchGroupByIdMock.mockResolvedValue(sampleGroup);
+  fetchBoardByIdMock.mockResolvedValue(sampleBoard);
+  getBoardUserStatusMock.mockResolvedValue(sampleStatus);
+}
+
+describe("BoardDetailView.vue", () => {
+  beforeEach(() => {
+    // auth 초기화
+    const auth = useAuthStoreMock();
+    auth.user.value = {
+      id: 1,
+      name: "이알고",
+      nickname: "algoLee",
+    };
+
+    // members 초기화
+    membersRef.value = [
+      { id: 1, name: "이알고", nickname: "algoLee" },
+      { id: 2, name: "달피곰", nickname: "baekjoonPark" },
+      { id: 3, name: "집에갈까요", nickname: "campChoi" },
+    ];
+
+    fetchGroupByIdMock.mockReset();
+    fetchBoardByIdMock.mockReset();
+    getBoardUserStatusMock.mockReset();
+    pushMock.mockReset();
+  });
+
+  it("마운트 시 그룹/보드/상태 API 를 호출하고 헤더 정보와 통계가 렌더링된다", async () => {
+    setupSuccessMocks();
+
+    const wrapper = mount(BoardDetailView);
+    await flushPromises();
+
+    expect(fetchGroupByIdMock).toHaveBeenCalledWith(1);
+    expect(fetchBoardByIdMock).toHaveBeenCalledWith(10);
+    expect(getBoardUserStatusMock).toHaveBeenCalledWith(1, 10);
+
+    expect(wrapper.text()).toContain("2023년 상반기 회고");
+    expect(wrapper.text()).toContain("CS 면접 대비반");
+    expect(wrapper.text()).toContain("문제 2개");
+    expect(wrapper.text()).toContain("참여 3명");
+
+    // 평균 완료율: 4 / (2문제 * 3명) = 66.7 → 67%
+    expect(wrapper.text()).toContain("전체 평균 완료율");
+    expect(wrapper.text()).toContain("67%");
+
+    // 내 완료율: 2 / 2 = 100%
+    expect(wrapper.text()).toContain("내 완료율");
+    expect(wrapper.text()).toContain("100%");
+  });
+
+  it("API 에러 발생 시 에러 메시지를 보여준다", async () => {
+    fetchGroupByIdMock.mockRejectedValue(new Error("network error"));
+    fetchBoardByIdMock.mockResolvedValue(sampleBoard);
+    getBoardUserStatusMock.mockResolvedValue(sampleStatus);
+
+    const wrapper = mount(BoardDetailView);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "보드 정보를 불러오는 중 오류가 발생했습니다.",
+    );
+  });
+
+  it("문제 기준 보기에서 문제 x 사용자 매트릭스를 렌더링한다", async () => {
+    setupSuccessMocks();
+
+    const wrapper = mount(BoardDetailView);
+    await flushPromises();
+
+    // 헤더에 참여 사용자 이름이 모두 보이는지
+    const headerText = wrapper.find("thead").text();
+    expect(headerText).toContain("이알고");
+    expect(headerText).toContain("달피곰");
+    expect(headerText).toContain("집에갈까요");
+
+    const firstRow = wrapper.find("tbody tr");
+    const cells = firstRow.findAll("td");
+
+    // 첫 번째 문제는 1008 (A@B)
+    expect(cells[0].text()).toContain("A@B");
+
+    // user1, user2 풀었고 user3는 못 풀었다 → ✅, ✅, ···
+    expect(cells[1].text()).toContain("✅");
+    expect(cells[2].text()).toContain("✅");
+    expect(cells[3].text()).toContain("···");
+  });
+
+  it("사용자 기준 보기 탭 클릭 시 사용자 카드와 완료율이 렌더링된다", async () => {
+    setupSuccessMocks();
+
+    const wrapper = mount(BoardDetailView);
+    await flushPromises();
+
+    // 탭 전환
+    const userTab = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("사용자 기준 보기"));
+    await userTab.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.text()).toContain(
+      "각 사용자별로 이번 보드에서 어떤 문제를 풀었는지 확인할 수 있습니다.",
+    );
+
+    // 사용자 카드 이름
+    const text = wrapper.text();
+    expect(text).toContain("이알고");
+    expect(text).toContain("달피곰");
+    expect(text).toContain("집에갈까요");
+
+    // 완료율: 100%, 50% 정도가 포함되어 있는지만 확인
+    expect(text).toContain("100%");
+    expect(text).toContain("50%");
+  });
+
+  it("내 현황만 보기 체크 시 현재 로그인 유저만 테이블에 표시된다", async () => {
+    setupSuccessMocks();
+
+    const wrapper = mount(BoardDetailView);
+    await flushPromises();
+
+    // 초기: 문제 + 3명 컬럼
+    const thAll = wrapper.findAll("thead th");
+    expect(thAll.length).toBe(4);
+
+    const checkbox = wrapper.get("input[type='checkbox']");
+    await checkbox.setValue(true);
+    await flushPromises();
+    await nextTick();
+
+    const thAfter = wrapper.findAll("thead th");
+    // 문제 + 나 1명
+    expect(thAfter.length).toBe(2);
+
+    const headerText = wrapper.find("thead").text();
+    expect(headerText).toContain("이알고");
+    expect(headerText).not.toContain("달피곰");
+    expect(headerText).not.toContain("집에갈까요");
+  });
+
+  it("로그인하지 않은 경우 내 완료율 카드가 보이지 않고 '내 현황만 보기' 체크박스가 비활성화된다", async () => {
+    // user 를 null 로 변경
+    const auth = useAuthStoreMock();
+    auth.user.value = null;
+
+    setupSuccessMocks();
+
+    const wrapper = mount(BoardDetailView);
+    await flushPromises();
+
+    // 내 완료율 카드가 없음
+    expect(wrapper.text()).not.toContain("내 완료율");
+
+    // 체크박스 disabled
+    const checkbox = wrapper.get("input[type='checkbox']");
+    expect(checkbox.attributes("disabled")).toBeDefined();
+  });
+
+  it("상단 '보드 목록으로' 버튼 클릭 시 BoardList 라우트로 이동한다", async () => {
+    setupSuccessMocks();
+
+    const wrapper = mount(BoardDetailView);
+    await flushPromises();
+
+    const backBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("보드 목록으로"));
+
+    await backBtn.trigger("click");
+
+    expect(pushMock).toHaveBeenCalledWith({
+      name: "BoardList",
+      params: { groupId: 1 },
+    });
+  });
+});

--- a/tests/BoardList.spec.js
+++ b/tests/BoardList.spec.js
@@ -82,10 +82,18 @@ import {
   fetchBoards as fetchBoardsMock,
 } from "@/data/boardStore";
 import { fetchGroupById as fetchGroupByIdMock } from "@/data/groupStore";
+import { useAuthStore } from "@/data/authStore";
 
 describe("BoardList.vue", () => {
   beforeEach(() => {
     // 각 테스트 시작 전에 mock 상태 초기화
+    const auth = useAuthStore();
+    auth.user.value = {
+      id: 1,
+      name: "테스트 유저",
+    };
+    auth.isAuthenticated.value = true;
+
     boardsRef.value = [
       {
         id: 1,
@@ -230,5 +238,72 @@ describe("BoardList.vue", () => {
     expect(wrapper.text()).not.toContain("알고리즘 스터디 1차");
 
     confirmSpy.mockRestore();
+  });
+
+  it("권한이 없는 사용자는 보드 만들기/수정/삭제 버튼을 볼 수 없다", async () => {
+    // 🔁 authStore의 user를 owner/manager가 아닌 아이디로 변경
+    const auth = useAuthStore();
+    auth.user.value = { id: 999, name: "일반 유저" };
+
+    const wrapper = mount(BoardList);
+    await flushPromises();
+    await nextTick();
+
+    // 상단의 '+ 보드 만들기' 버튼이 없어야 함
+    const createButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("+ 보드 만들기"));
+    expect(createButton).toBeUndefined();
+
+    // 카드 안에 '수정', '삭제' 텍스트도 없어야 함
+    // (card 자체를 눌러 이동하는 버튼은 그대로 있음)
+    expect(wrapper.text()).not.toContain("수정");
+    expect(wrapper.text()).not.toContain("삭제");
+  });
+
+  it("지난 보드 탭에서는 수정 버튼이 표시되지 않고 삭제 버튼만 남는다", async () => {
+    const wrapper = mount(BoardList);
+    await flushPromises();
+    await nextTick();
+
+    // '지난 보드' 탭 클릭
+    const pastTabButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("지난 보드"));
+    await pastTabButton.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    const pastItem = wrapper.find("li.group");
+    expect(pastItem.exists()).toBe(true);
+
+    // 지난 보드 카드에는 '수정' 버튼이 없어야 함
+    const editBtn = pastItem
+      .findAll("button")
+      .find((btn) => btn.text().includes("수정"));
+    expect(editBtn).toBeUndefined();
+
+    // 대신 '삭제' 버튼은 있어야 함
+    const deleteBtn = pastItem
+      .findAll("button")
+      .find((btn) => btn.text().includes("삭제"));
+    expect(deleteBtn).toBeTruthy();
+  });
+
+  it("탭의 배지 숫자가 진행/지난 보드 개수와 일치한다", async () => {
+    const wrapper = mount(BoardList);
+    await flushPromises();
+    await nextTick();
+
+    const activeTabButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("진행 중인 보드"));
+    const pastTabButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("지난 보드"));
+
+    // boardsRef 초기값에서 진행중: 1개, 지난 보드: 1개
+    expect(activeTabButton.text()).toContain("1");
+    expect(pastTabButton.text()).toContain("1");
   });
 });


### PR DESCRIPTION
이슈 번호 : https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/18
---
### ✅ 이 PR에서 구현한 내용 (What & Why)

* **보드별 문제 풀이 현황을 한 화면에서 볼 수 있는 BoardDetail 뷰 구현**

  * `/groups/:groupId/boards/:boardId` 라우트 추가
  * 문제 × 사용자 매트릭스로 “누가 어떤 문제를 풀었는지” 한눈에 파악
* **보드 유저 상태 API + Mock 연동**

  * `getBoardUserStatus(groupId, boardId)` 도입
  * 현재는 mock 기반으로 동작하며, 추후 실서버 연동 시 동일 인터페이스 유지
* **BoardList → BoardDetail 네비게이션 플로우 정리**

  * 보드 카드 클릭 시 상세 페이지 이동
  * 상세 상단에서 “보드 목록으로” 버튼으로 되돌아오기 가능
* **역할/로그인 상태를 반영한 UI**

  * 로그인 유저 기준 `내 완료율`, `내 현황만 보기` 필터 제공
  * 비로그인 상태에서는 관련 UI 비노출 (오해 줄이기)

---

### 📂 변경된 주요 컴포넌트/모듈 (Where)

* **뷰**

  * `src/views/BoardDetailView.vue`

    * 보드/그룹 정보 및 보드 유저 상태를 불러와서 화면 구성
    * 문제 기준 / 사용자 기준 탭 전환
    * 전체/개인 완료율 계산 및 렌더링
* **라우터**

  * `src/router/index.js`

    * `BoardDetail` 라우트 추가
      `path: "/groups/:groupId/boards/:boardId"`, `name: "BoardDetail"`
    * `requiresAuth`, `requiresGroupMember` 메타로 그룹 멤버만 접근 가능
* **컴포넌트**

  * `src/components/BoardList.vue`

    * 카드 클릭 시 `BoardDetail`로 이동하는 `goBoardDetail` 함수 추가
    * “보드 목록으로” 클릭 시 해당 그룹의 보드 리스트로 라우팅
* **API & Mock**

  * `src/api/boardApi.js`

    * `getBoardUserStatus(groupId, boardId)`

      * `USE_MOCK` 플래그로 mock/실서버 전환 가능
  * `src/api/mockBoardUserStatusApi.js`

    * 그룹/보드별 문제 풀이 현황 mock 데이터(`MOCK_STATUS_BY_BOARD`) 정의
* **테스트**

  * `tests/BoardList.spec.js`

    * `useAuthStore` 기반으로 권한 있는/없는 유저 시나리오 검증
    * 진행/지난 보드 탭, 버튼 노출 여부 테스트
  * `tests/BoardDetailView.spec.js`

    * 보드/그룹/유저 상태 mock 후

      * 헤더 정보, 평균/개인 완료율, 탭 전환, 내 현황 필터링, 라우터 이동까지 e2e에 가까운 뷰 테스트

---

### 🧪 동작 흐름/사용 시나리오 (How)

1. **보드 목록에서 카드 클릭**

   * `/groups/:groupId/boards` 진입 → 특정 보드 카드 클릭
   * `BoardDetail` 라우트로 이동 (`/groups/:groupId/boards/:boardId`)

2. **BoardDetail 진입 시 초기 데이터 로딩**

   * `groupId`, `boardId` 기준으로:

     * `fetchGroupById(groupId)`
     * `fetchBoardById(boardId)`
     * `getBoardUserStatus(groupId, boardId)` 호출
   * 응답 기반으로:

     * 보드 제목, 그룹명, 문제 개수, 참여 인원 수, 전체 평균 완료율 계산

3. **문제 기준 / 사용자 기준 보기**

   * 기본: **문제 기준**

     * 행 = 문제, 열 = 사용자, 셀 = 풀이 여부
   * 탭 전환: **사용자 기준**

     * 카드별로 각 사용자가 푼 문제 목록 + 완료율 표시

4. **내 현황만 보기**

   * 로그인 상태:

     * `내 완료율` 카드와 `내 현황만 보기` 체크박스 노출
     * 체크 시 표에서 현재 로그인 유저만 남기고 나머지 숨김
   * 비로그인:

     * 관련 UI 비노출 / disabled 처리

5. **보드 목록으로 돌아가기**

   * 상단 “보드 목록으로” 클릭 시
     `router.push({ name: "BoardList", params: { groupId } })`로 이동

---

### 💡 기타 (Risk / Rollout / Follow-up)

* **리스크/영향도**

  * 신규 라우트 & 뷰 추가 중심이라 기존 보드 CRUD 기능에는 영향 없음
  * 유저 상태 API는 mock 기반이라, 실서버 연동 시 response shape만 맞으면 그대로 재사용 가능
* **테스트**

  * `npm run test` 기준으로 BoardList/BoardDetail 관련 테스트 추가/보강
  * 라우터/스토어/뷰를 통합한 시나리오 테스트를 포함해, 회귀 가능성을 최대한 줄였음
* **후속 작업 아이디어**

  * BoardDetail에서 **문제 난이도/태그** 필터 추가
  * 실서버 API 붙인 뒤, mock 데이터는 fixture 폴더로 이동하거나 별도 패키지로 분리
