### PR TITLE
[BST-20] 회원가입, 마이페이지에 백준 아이디 검증/저장 플로우 추가

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -45,6 +45,34 @@ export async function checkUsernameDuplicate({ username }) {
 }
 
 /**
+ * 백엔드에서 Baekjoon 프로필 존재 여부 확인
+ * GET /api/v1/baekjoon/verify?handle=xxx
+ */
+export async function verifyBaekjoonId({ handle }) {
+  const response = await httpClient.get("/v1/baekjoon/verify", {
+    params: { handle },
+  });
+
+  // 예시 응답: { exists: true }
+  return response.data;
+}
+
+/**
+ * 내 계정에 연결된 Baekjoon 아이디 저장/수정
+ * PATCH /api/v1/members/me/baekjoon-id
+ *  - body: { baekjoonId: "handle" }
+ *  - 실제 엔드포인트는 백엔드 설계에 맞게 변경하면 됨
+ */
+export async function updateBaekjoonId({ baekjoonId }) {
+  const response = await httpClient.patch("/v1/members/me/baekjoon-id", {
+    baekjoonId,
+  });
+
+  // 예시 응답: { user: { ..., baekjoonId: "xxx" } } 또는 { ok: true }
+  return response.data;
+}
+
+/**
  * 로그아웃 (세션 기반)
  */
 export async function logout() {

--- a/src/api/mockAuthApi.js
+++ b/src/api/mockAuthApi.js
@@ -69,8 +69,34 @@ export async function mockCheckUsernameDuplicate({ username }) {
   };
 }
 
+/**
+ * 백준 아이디 존재 여부 확인 mock
+ *   - 실제 서비스에서는 서버에서 Baekjoon 또는 solved.ac API를 호출해서
+ *     존재 여부를 판별할 예정.
+ *   - 지금은 단순 규칙으로:
+ *     - handle가 "unknown", "notfound" 이면 없는 계정으로 처리
+ *     - 그 외는 있는 계정으로 가정
+ */
+export async function mockCheckBaekjoonId({ handle }) {
+  await delay(300);
+
+  const trimmed = (handle || "").trim();
+  if (!trimmed) {
+    return { exists: false };
+  }
+
+  const lower = trimmed.toLowerCase();
+  const invalidList = ["unknown", "notfound", "invalid"];
+
+  const exists = !invalidList.includes(lower);
+
+  return {
+    exists,
+  };
+}
+
 // ===== 회원가입 (ID/PW 기반) =====
-export async function mockSignup({ email, nickname, password }) {
+export async function mockSignup({ email, nickname, password, baekjoonId }) {
   await delay(500);
 
   const users = loadUsers();
@@ -87,6 +113,7 @@ export async function mockSignup({ email, nickname, password }) {
     email,
     nickname,
     password, // ⚠️ 실제 프로덕션에서는 평문 저장 금지 (BCrypt 등 사용)
+    baekjoonId,
   };
 
   const nextUsers = [...users, newUser];
@@ -98,6 +125,7 @@ export async function mockSignup({ email, nickname, password }) {
       id: newUser.id,
       email: newUser.email,
       nickname: newUser.nickname,
+      baekjoonId: newUser.baekjoonId,
     },
   };
 
@@ -280,6 +308,7 @@ export async function mockVerifyPassword({ password }) {
       id: user.id,
       email: user.email,
       nickname: user.nickname,
+      baekjoonId: user.baekjoonId,
     },
   };
 }
@@ -324,6 +353,51 @@ export async function mockUpdateNickname({ nickname }) {
       id: users[idx].id,
       email: users[idx].email,
       nickname: users[idx].nickname,
+    },
+  };
+}
+
+export async function mockUpdateBaekjoonId({ baekjoonId }) {
+  await delay(400);
+
+  const current = mockGetCurrentUser();
+  if (!current) {
+    const error = new Error("로그인 상태가 아닙니다.");
+    error.code = "NOT_LOGGED_IN";
+    throw error;
+  }
+
+  const users = loadUsers();
+  const idx = users.findIndex((u) => u.id === current.id);
+
+  if (idx === -1) {
+    const error = new Error("사용자를 찾을 수 없습니다.");
+    error.code = "USER_NOT_FOUND";
+    throw error;
+  }
+
+  users[idx].baekjoonId = baekjoonId;
+  saveUsers(users);
+
+  // currentUser 캐시도 최신 백준 아이디로 업데이트
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(
+      STORAGE_KEY_CURRENT_USER,
+      JSON.stringify({
+        id: users[idx].id,
+        email: users[idx].email,
+        nickname: users[idx].nickname,
+        baekjoonId: users[idx].baekjoonId,
+      }),
+    );
+  }
+
+  return {
+    user: {
+      id: users[idx].id,
+      email: users[idx].email,
+      nickname: users[idx].nickname,
+      baekjoonId: users[idx].baekjoonId,
     },
   };
 }

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -13,6 +13,8 @@ import {
   mockChangePassword,
   mockDeleteAccount,
   mockCheckUsernameDuplicate,
+  mockCheckBaekjoonId,
+  mockUpdateBaekjoonId,
 } from "../api/mockAuthApi";
 
 const router = useRouter();
@@ -32,6 +34,15 @@ const verifyLoading = ref(false);
 const email = ref("");
 const nickname = ref("");
 const originalNickname = ref("");
+const baekjoonId = ref("");
+const originalBaekjoonId = ref("");
+
+// 백준 아이디 수정 상태
+const isEditingBaekjoonId = ref(false);
+const isSavingBaekjoonId = ref(false);
+const isCheckingBaekjoonId = ref(false);
+const baekjoonCheckMessage = ref("");
+const isBaekjoonValid = ref(null); // null: 모름, true: 존재, false: 없음
 
 // 닉네임 수정 상태
 const isEditingNickname = ref(false);
@@ -45,6 +56,13 @@ watch(nickname, () => {
   if (!isEditingNickname.value) return;
   isNicknameDuplicated.value = null;
   nicknameCheckMessage.value = "";
+});
+
+// 백준 아이디가 바뀌면 검증 결과는 무효화
+watch(baekjoonId, () => {
+  if (!isEditingBaekjoonId.value) return;
+  isBaekjoonValid.value = null;
+  baekjoonCheckMessage.value = "";
 });
 
 // ===== 3영역: 비밀번호 변경 =====
@@ -100,6 +118,8 @@ async function handleVerifyPassword() {
     email.value = user.email;
     nickname.value = user.nickname;
     originalNickname.value = user.nickname;
+    baekjoonId.value = user.baekjoonId || "";
+    originalBaekjoonId.value = user.baekjoonId || "";
 
     step.value = "profile";
     verifyPasswordInput.value = "";
@@ -232,6 +252,113 @@ async function handleSaveNickname() {
     console.log(e);
   } finally {
     isSavingNickname.value = false;
+  }
+}
+
+// ===== 백준 아이디 확인 =====
+async function handleCheckBaekjoonId() {
+  baekjoonCheckMessage.value = "";
+  isBaekjoonValid.value = null;
+
+  const handle = baekjoonId.value.trim();
+  if (!handle) {
+    baekjoonCheckMessage.value = "백준 아이디를 먼저 입력해주세요.";
+    return;
+  }
+
+  // 지금 등록된 아이디와 동일하면 그냥 유효로 처리
+  if (handle === (originalBaekjoonId.value || "")) {
+    isBaekjoonValid.value = true;
+    baekjoonCheckMessage.value = "현재 등록된 백준 아이디입니다.";
+    return;
+  }
+
+  isCheckingBaekjoonId.value = true;
+
+  try {
+    // TODO: 실제 백엔드로 교체 예정
+    const res = await mockCheckBaekjoonId({ handle });
+    if (res.exists) {
+      isBaekjoonValid.value = true;
+      baekjoonCheckMessage.value = "존재하는 백준 아이디입니다.";
+    } else {
+      isBaekjoonValid.value = false;
+      baekjoonCheckMessage.value =
+        "존재하지 않는 백준 아이디입니다. 다시 확인해주세요.";
+    }
+  } catch (e) {
+    console.error(e);
+    isBaekjoonValid.value = null;
+    baekjoonCheckMessage.value =
+      "백준 아이디 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+  } finally {
+    isCheckingBaekjoonId.value = false;
+  }
+}
+
+function startEditBaekjoonId() {
+  isEditingBaekjoonId.value = true;
+  baekjoonCheckMessage.value = "";
+  isBaekjoonValid.value = null;
+}
+
+function cancelEditBaekjoonId() {
+  isEditingBaekjoonId.value = false;
+  baekjoonId.value = originalBaekjoonId.value || "";
+  baekjoonCheckMessage.value = "";
+  isBaekjoonValid.value = null;
+}
+
+// ===== 백준 아이디 저장 =====
+async function handleSaveBaekjoonId() {
+  globalError.value = "";
+  globalMessage.value = "";
+
+  const value = baekjoonId.value.trim();
+
+  if (!value) {
+    globalError.value = "백준 아이디를 비울 수 없습니다.";
+    return;
+  }
+
+  // 변경 없으면 그냥 종료
+  if (value === (originalBaekjoonId.value || "")) {
+    isEditingBaekjoonId.value = false;
+    baekjoonCheckMessage.value = "";
+    isBaekjoonValid.value = null;
+    return;
+  }
+
+  // 존재하지 않는 아이디면 막기
+  if (isBaekjoonValid.value !== true) {
+    globalError.value =
+      "백준 아이디가 실제로 존재하는지 확인 버튼을 눌러주세요.";
+    return;
+  }
+
+  isSavingBaekjoonId.value = true;
+
+  try {
+    // TODO: 실제 서버 API로 전환 예정
+    const res = await mockUpdateBaekjoonId({ baekjoonId: value });
+    const user = res.user;
+
+    baekjoonId.value = user.baekjoonId || "";
+    originalBaekjoonId.value = user.baekjoonId || "";
+
+    isEditingBaekjoonId.value = false;
+    baekjoonCheckMessage.value = "";
+    isBaekjoonValid.value = null;
+    globalMessage.value = "백준 아이디가 변경되었습니다.";
+
+    // 헤더/전역 상태 동기화
+    await authStore.fetchCurrentUser({ force: true });
+  } catch (e) {
+    globalError.value =
+      "백준 아이디를 변경하는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
+    console.log(e);
+  } finally {
+    isSavingBaekjoonId.value = false;
   }
 }
 
@@ -440,6 +567,78 @@ async function handleDeleteAccount() {
                   <span>{{ email }}</span>
                   <span class="text-[11px] text-gray-400"> 로그인 ID </span>
                 </div>
+              </div>
+
+              <div>
+                <label
+                  for="mypage-baekjoon-id"
+                  class="block text-xs font-medium text-gray-500 mb-1"
+                >
+                  백준 아이디
+                </label>
+
+                <div class="flex gap-2 items-center">
+                  <input
+                    id="mypage-baekjoon-id"
+                    v-model="baekjoonId"
+                    :disabled="!isEditingBaekjoonId"
+                    type="text"
+                    class="flex-1 rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 disabled:bg-gray-50 disabled:text-gray-500"
+                    placeholder="백준 온라인 저지 아이디"
+                  />
+                  <button
+                    v-if="!isEditingBaekjoonId"
+                    type="button"
+                    class="shrink-0 rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100"
+                    @click="startEditBaekjoonId"
+                  >
+                    아이디 수정
+                  </button>
+                </div>
+
+                <!-- 백준 아이디 수정 모드 -->
+                <div
+                  v-if="isEditingBaekjoonId"
+                  class="mt-2 flex flex-wrap items-center gap-2"
+                >
+                  <button
+                    type="button"
+                    class="rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
+                    :disabled="isCheckingBaekjoonId || !baekjoonId.trim()"
+                    @click="handleCheckBaekjoonId"
+                  >
+                    <span v-if="!isCheckingBaekjoonId">아이디 확인</span>
+                    <span v-else>확인 중...</span>
+                  </button>
+
+                  <button
+                    type="button"
+                    class="rounded-lg bg-yellow-400 px-3 py-1.5 text-xs font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed"
+                    :disabled="isSavingBaekjoonId"
+                    @click="handleSaveBaekjoonId"
+                  >
+                    <span v-if="!isSavingBaekjoonId">저장</span>
+                    <span v-else>저장 중...</span>
+                  </button>
+
+                  <button
+                    type="button"
+                    class="rounded-lg border border-transparent px-2 py-1 text-xs text-gray-500 hover:text-gray-700"
+                    @click="cancelEditBaekjoonId"
+                  >
+                    취소
+                  </button>
+                </div>
+
+                <p
+                  v-if="baekjoonCheckMessage"
+                  class="mt-1 text-xs"
+                  :class="
+                    isBaekjoonValid === true ? 'text-green-600' : 'text-red-600'
+                  "
+                >
+                  {{ baekjoonCheckMessage }}
+                </p>
               </div>
 
               <div>

--- a/src/views/SignupView.vue
+++ b/src/views/SignupView.vue
@@ -3,10 +3,14 @@ import { ref, watch, computed } from "vue";
 import { useRouter } from "vue-router";
 
 // TODO: 실제 회원가입 API (ID/PW 기반)
-// import { signupWithIdPw, checkUsernameDuplicate } from "@/api/authApi";
+// import { signupWithIdPw, checkUsernameDuplicate, verifyBaekjoonId } from "@/api/authApi";
 
 // TODO: TODO: mock 버전
-import { mockSignup, mockCheckUsernameDuplicate } from "../api/mockAuthApi";
+import {
+  mockSignup,
+  mockCheckUsernameDuplicate,
+  mockCheckBaekjoonId,
+} from "../api/mockAuthApi";
 
 const router = useRouter();
 
@@ -21,12 +25,17 @@ const canProceedTerms = computed(
 );
 
 const email = ref("");
+const baekjoonId = ref("");
 const nickname = ref("");
 const password = ref("");
 const passwordConfirm = ref("");
 
 const isSubmitting = ref(false);
 const errorMessage = ref("");
+
+const isCheckingBaekjoon = ref(false);
+const baekjoonCheckMessage = ref("");
+const isBaekjoonValid = ref(null); // null: 아직 모름, true: 존재, false: 없음
 
 const isCheckingNickname = ref(false);
 const nicknameCheckMessage = ref("");
@@ -35,6 +44,11 @@ const isNicknameDuplicated = ref(null); // null: 아직 모름, true: 중복, fa
 watch(nickname, () => {
   isNicknameDuplicated.value = null;
   nicknameCheckMessage.value = "";
+});
+
+watch(baekjoonId, () => {
+  isBaekjoonValid.value = null;
+  baekjoonCheckMessage.value = "";
 });
 
 function goToFormStep() {
@@ -88,11 +102,59 @@ async function handleCheckNickname() {
   }
 }
 
+async function handleCheckBaekjoonId() {
+  baekjoonCheckMessage.value = "";
+  isBaekjoonValid.value = null;
+
+  const handle = baekjoonId.value.trim();
+  if (!handle) {
+    baekjoonCheckMessage.value = "백준 아이디를 먼저 입력해주세요.";
+    return;
+  }
+
+  isCheckingBaekjoon.value = true;
+
+  try {
+    // TODO: 지금은 mock, 나중에 서버 API로 교체
+    const res = await mockCheckBaekjoonId({ handle });
+    // 가정: { exists: boolean }
+    if (res.exists) {
+      isBaekjoonValid.value = true;
+      baekjoonCheckMessage.value = "존재하는 백준 아이디입니다.";
+    } else {
+      isBaekjoonValid.value = false;
+      baekjoonCheckMessage.value =
+        "존재하지 않는 백준 아이디입니다. 다시 확인해주세요.";
+    }
+
+    // TODO: 실제 API 예시
+    // const res = await verifyBaekjoonId({ handle });
+    // isBaekjoonValid.value = res.exists;
+  } catch (e) {
+    console.error(e);
+    isBaekjoonValid.value = null;
+    baekjoonCheckMessage.value =
+      "백준 아이디 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+  } finally {
+    isCheckingBaekjoon.value = false;
+  }
+}
+
 function validate() {
   errorMessage.value = "";
 
   if (!email.value.trim() || !nickname.value.trim()) {
     errorMessage.value = "이메일과 닉네임을 모두 입력해주세요.";
+    return false;
+  }
+
+  if (!baekjoonId.value.trim()) {
+    errorMessage.value = "백준 아이디를 입력해주세요.";
+    return false;
+  }
+
+  if (isBaekjoonValid.value !== true) {
+    errorMessage.value = "백준 아이디가 존재하는지 확인 버튼을 눌러주세요.";
     return false;
   }
 
@@ -125,6 +187,7 @@ async function handleSubmit() {
       email: email.value,
       nickname: nickname.value,
       password: password.value,
+      baekjoonId: baekjoonId.value,
     });
 
     // TODO: 2) 나중: 실제 API
@@ -132,6 +195,7 @@ async function handleSubmit() {
     //   email: email.value,
     //   nickname: nickname.value,
     //   password: password.value,
+    //   baekjoonId: baekjoonId.value,
     // });
 
     router.push({ name: "Login" });
@@ -273,6 +337,44 @@ function goToLogin() {
               class="block w-full rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
               placeholder="you@example.com"
             />
+          </div>
+
+          <div>
+            <label
+              for="baekjoon-id"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              백준 아이디
+            </label>
+            <div class="flex gap-2">
+              <input
+                id="baekjoon-id"
+                v-model="baekjoonId"
+                type="text"
+                autocomplete="off"
+                required
+                class="flex-1 rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400"
+                placeholder="백준 온라인 저지 아이디"
+              />
+              <button
+                type="button"
+                class="shrink-0 rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
+                :disabled="isCheckingBaekjoon || !baekjoonId.trim()"
+                @click="handleCheckBaekjoonId"
+              >
+                <span v-if="!isCheckingBaekjoon">아이디 확인</span>
+                <span v-else>확인 중...</span>
+              </button>
+            </div>
+            <p
+              v-if="baekjoonCheckMessage"
+              class="mt-1 text-xs"
+              :class="
+                isBaekjoonValid === true ? 'text-green-600' : 'text-red-600'
+              "
+            >
+              {{ baekjoonCheckMessage }}
+            </p>
           </div>
 
           <div>

--- a/tests/MyPageView.spec.js
+++ b/tests/MyPageView.spec.js
@@ -47,6 +47,8 @@ async function goToProfileStep(wrapper, overrides = {}) {
   wrapper.vm.email = overrides.email ?? "user@example.com";
   wrapper.vm.nickname = overrides.nickname ?? "oldNick";
   wrapper.vm.originalNickname = overrides.originalNickname ?? "oldNick";
+  wrapper.vm.baekjoonId = overrides.baekjoonId ?? "";
+  wrapper.vm.originalBaekjoonId = overrides.originalBaekjoonId ?? "";
   await nextTick();
 }
 
@@ -110,13 +112,14 @@ describe("MyPageView.vue", () => {
     expect(verifySpy).not.toHaveBeenCalled();
   });
 
-  it("올바른 비밀번호 입력 시 mockVerifyPassword 호출 후 프로필 단계로 전환된다", async () => {
+  it("올바른 비밀번호 입력 시 mockVerifyPassword 호출 후 프로필 단계로 전환되고, 이메일/닉네임/백준 아이디가 세팅된다", async () => {
     const verifySpy = vi
       .spyOn(mockAuthApi, "mockVerifyPassword")
       .mockResolvedValue({
         user: {
           email: "me@example.com",
           nickname: "myNick",
+          baekjoonId: "tourist",
         },
       });
 
@@ -140,6 +143,9 @@ describe("MyPageView.vue", () => {
 
     const nicknameInput = wrapper.get("#mypage-nickname");
     expect(nicknameInput.element.value).toBe("myNick");
+
+    const baekjoonInput = wrapper.get("#mypage-baekjoon-id");
+    expect(baekjoonInput.element.value).toBe("tourist");
   });
 
   it("비밀번호가 틀리면 에러 메시지를 보여준다", async () => {
@@ -272,6 +278,231 @@ describe("MyPageView.vue", () => {
     expect(g.fetchCurrentUserMock).toHaveBeenCalledWith({ force: true });
     expect(wrapper.text()).toContain("닉네임이 변경되었습니다.");
   });
+
+  // ============================
+  // 백준 아이디 관련 테스트
+  // ============================
+
+  it("백준 아이디 입력이 없으면 '아이디 확인' 버튼이 비활성화되고 mockCheckBaekjoonId를 호출하지 않는다", async () => {
+    const checkSpy = vi
+      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
+      .mockResolvedValue({ exists: true });
+
+    const wrapper = mount(MyPageView);
+    await flushPromises();
+
+    // 프로필 단계 & 백준 아이디 없음으로 세팅
+    await goToProfileStep(wrapper, {
+      baekjoonId: "",
+      originalBaekjoonId: "",
+    });
+
+    // "아이디 수정" 눌러서 편집 모드 진입
+    const editBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 수정"));
+    await editBtn.trigger("click");
+    await flushPromises();
+
+    // "아이디 확인" 버튼 찾기
+    const checkBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 확인"));
+
+    // 입력이 없으므로 버튼이 비활성화되어 있어야 한다
+    expect(checkBtn.element.disabled).toBe(true);
+
+    // 클릭해도 실제 API는 호출되지 않아야 한다
+    await checkBtn.trigger("click");
+    await flushPromises();
+
+    expect(checkSpy).not.toHaveBeenCalled();
+  });
+
+  it("현재 등록된 백준 아이디와 동일한 값을 확인하면 API 호출 없이 유효 처리한다", async () => {
+    const checkSpy = vi
+      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
+      .mockResolvedValue({ exists: true });
+
+    const wrapper = mount(MyPageView);
+    await flushPromises();
+    await goToProfileStep(wrapper, {
+      baekjoonId: "tourist",
+      originalBaekjoonId: "tourist",
+    });
+
+    const editBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 수정"));
+    await editBtn.trigger("click");
+    await flushPromises();
+
+    const checkBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 확인"));
+    await checkBtn.trigger("click");
+    await flushPromises();
+
+    expect(checkSpy).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain("현재 등록된 백준 아이디입니다.");
+  });
+
+  it("존재하는 백준 아이디라면 아이디 확인 시 성공 메시지를 보여준다", async () => {
+    const checkSpy = vi
+      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
+      .mockResolvedValue({ exists: true });
+
+    const wrapper = mount(MyPageView);
+    await flushPromises();
+    await goToProfileStep(wrapper, {
+      baekjoonId: "",
+      originalBaekjoonId: "",
+    });
+
+    const editBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 수정"));
+    await editBtn.trigger("click");
+    await flushPromises();
+
+    await wrapper.get("#mypage-baekjoon-id").setValue("tourist");
+
+    const checkBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 확인"));
+    await checkBtn.trigger("click");
+    await flushPromises();
+
+    expect(checkSpy).toHaveBeenCalledWith({ handle: "tourist" });
+    expect(wrapper.text()).toContain("존재하는 백준 아이디입니다.");
+  });
+
+  it("백준 아이디 확인 없이 저장 시 에러를 보여주고 mockUpdateBaekjoonId를 호출하지 않는다", async () => {
+    const updateSpy = vi
+      .spyOn(mockAuthApi, "mockUpdateBaekjoonId")
+      .mockResolvedValue({
+        user: {
+          email: "user@example.com",
+          nickname: "oldNick",
+          baekjoonId: "tourist",
+        },
+      });
+
+    const wrapper = mount(MyPageView);
+    await flushPromises();
+    await goToProfileStep(wrapper, {
+      baekjoonId: "",
+      originalBaekjoonId: "",
+    });
+
+    const editBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 수정"));
+    await editBtn.trigger("click");
+    await flushPromises();
+
+    await wrapper.get("#mypage-baekjoon-id").setValue("tourist");
+
+    const saveBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("저장"));
+    await saveBtn.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "백준 아이디가 실제로 존재하는지 확인 버튼을 눌러주세요.",
+    );
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("백준 아이디 확인 후 저장 시 mockUpdateBaekjoonId와 fetchCurrentUser를 호출한다", async () => {
+    const g = globalThis.__authMocks;
+
+    const checkSpy = vi
+      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
+      .mockResolvedValue({ exists: true });
+
+    const updateSpy = vi
+      .spyOn(mockAuthApi, "mockUpdateBaekjoonId")
+      .mockResolvedValue({
+        user: {
+          email: "user@example.com",
+          nickname: "oldNick",
+          baekjoonId: "tourist",
+        },
+      });
+
+    const wrapper = mount(MyPageView);
+    await flushPromises();
+    await goToProfileStep(wrapper, {
+      baekjoonId: "",
+      originalBaekjoonId: "",
+    });
+
+    const editBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 수정"));
+    await editBtn.trigger("click");
+    await flushPromises();
+
+    await wrapper.get("#mypage-baekjoon-id").setValue("tourist");
+
+    const checkBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 확인"));
+    await checkBtn.trigger("click");
+    await flushPromises();
+
+    const saveBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("저장"));
+    await saveBtn.trigger("click");
+    await flushPromises();
+
+    expect(checkSpy).toHaveBeenCalledWith({ handle: "tourist" });
+    expect(updateSpy).toHaveBeenCalledWith({ baekjoonId: "tourist" });
+    expect(g.fetchCurrentUserMock).toHaveBeenCalledWith({ force: true });
+    expect(wrapper.text()).toContain("백준 아이디가 변경되었습니다.");
+  });
+
+  it("백준 아이디를 빈 문자열로 저장하려 하면 에러를 보여주고 mockUpdateBaekjoonId를 호출하지 않는다", async () => {
+    const updateSpy = vi
+      .spyOn(mockAuthApi, "mockUpdateBaekjoonId")
+      .mockResolvedValue({
+        user: {
+          email: "user@example.com",
+          nickname: "oldNick",
+          baekjoonId: "",
+        },
+      });
+
+    const wrapper = mount(MyPageView);
+    await flushPromises();
+    await goToProfileStep(wrapper, {
+      baekjoonId: "tourist",
+      originalBaekjoonId: "tourist",
+    });
+
+    const editBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("아이디 수정"));
+    await editBtn.trigger("click");
+    await flushPromises();
+
+    await wrapper.get("#mypage-baekjoon-id").setValue("");
+    const saveBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("저장"));
+    await saveBtn.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("백준 아이디를 비울 수 없습니다.");
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  // ============================
+  // 비밀번호 / 탈퇴 기존 테스트
+  // ============================
 
   it("비밀번호 변경에서 8자 미만이면 에러를 보여주고 mockChangePassword를 호출하지 않는다", async () => {
     const changeSpy = vi

--- a/tests/SignupView.spec.js
+++ b/tests/SignupView.spec.js
@@ -16,8 +16,8 @@ async function goToFormStep(wrapper) {
   const checkboxes = wrapper.findAll('input[type="checkbox"]');
   expect(checkboxes.length).toBeGreaterThanOrEqual(2);
 
-  await checkboxes[0].setValue(true); // 필수1
-  await checkboxes[1].setValue(true); // 필수2
+  await checkboxes[0].setValue(true); // 필수 약관 1
+  await checkboxes[1].setValue(true); // 필수 약관 2
 
   const proceedButton = wrapper
     .findAll("button")
@@ -46,12 +46,71 @@ describe("SignupView", () => {
     expect(wrapper.text()).toContain("이메일과 닉네임을 모두 입력해주세요.");
   });
 
-  it("비밀번호와 확인이 다르면 에러를 보여준다", async () => {
+  it("백준 아이디가 비어 있으면 에러를 보여준다", async () => {
     const wrapper = mount(SignupView);
     await goToFormStep(wrapper);
 
     await wrapper.find("#signup-email").setValue("user@example.com");
     await wrapper.find("#nickname").setValue("user");
+    await wrapper.find("#signup-password").setValue("password123");
+    await wrapper.find("#signup-password-confirm").setValue("password123");
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("백준 아이디를 입력해주세요.");
+  });
+
+  it("백준 아이디 확인을 하지 않으면 에러를 보여주고 mockSignup을 호출하지 않는다", async () => {
+    const signupSpy = vi.spyOn(mockAuthApi, "mockSignup").mockResolvedValue({
+      user: {
+        id: 1,
+        email: "user@example.com",
+        nickname: "user",
+        baekjoonId: "tourist",
+      },
+    });
+
+    const wrapper = mount(SignupView);
+    await goToFormStep(wrapper);
+
+    await wrapper.find("#signup-email").setValue("user@example.com");
+    await wrapper.find("#baekjoon-id").setValue("tourist");
+    await wrapper.find("#nickname").setValue("user");
+    await wrapper.find("#signup-password").setValue("password123");
+    await wrapper.find("#signup-password-confirm").setValue("password123");
+
+    // 🔥 여기서 '아이디 확인' 버튼은 누르지 않음
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "백준 아이디가 존재하는지 확인 버튼을 눌러주세요.",
+    );
+    expect(signupSpy).not.toHaveBeenCalled();
+  });
+
+  it("비밀번호와 확인이 다르면 에러를 보여준다", async () => {
+    vi.spyOn(mockAuthApi, "mockCheckBaekjoonId").mockResolvedValue({
+      exists: true,
+    });
+
+    const wrapper = mount(SignupView);
+    await goToFormStep(wrapper);
+
+    await wrapper.find("#signup-email").setValue("user@example.com");
+    await wrapper.find("#baekjoon-id").setValue("tourist");
+    await wrapper.find("#nickname").setValue("user");
+
+    // 백준 아이디 확인
+    const bjCheckBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("아이디 확인"));
+    expect(bjCheckBtn).toBeTruthy();
+    await bjCheckBtn.trigger("click");
+    await flushPromises();
+
     await wrapper.find("#signup-password").setValue("password123");
     await wrapper.find("#signup-password-confirm").setValue("different123");
 
@@ -69,26 +128,95 @@ describe("SignupView", () => {
         id: 1,
         email: "user@example.com",
         nickname: "user",
+        baekjoonId: "tourist",
       },
     });
+
+    const baekjoonSpy = vi
+      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
+      .mockResolvedValue({
+        exists: true,
+      });
 
     const wrapper = mount(SignupView);
     await goToFormStep(wrapper);
 
     await wrapper.find("#signup-email").setValue("user@example.com");
+    await wrapper.find("#baekjoon-id").setValue("tourist");
     await wrapper.find("#nickname").setValue("user");
+
+    // 백준 아이디 확인
+    const bjCheckBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("아이디 확인"));
+    expect(bjCheckBtn).toBeTruthy();
+    await bjCheckBtn.trigger("click");
+    await flushPromises();
+
     await wrapper.find("#signup-password").setValue("password123");
     await wrapper.find("#signup-password-confirm").setValue("password123");
 
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
+    expect(baekjoonSpy).toHaveBeenCalledWith({ handle: "tourist" });
     expect(signupSpy).toHaveBeenCalledWith({
       email: "user@example.com",
       nickname: "user",
       password: "password123",
+      baekjoonId: "tourist",
     });
     expect(pushMock).toHaveBeenCalledWith({ name: "Login" });
+  });
+
+  it("백준 아이디 확인 버튼 클릭 시 mockCheckBaekjoonId를 호출하고 존재하는 아이디면 성공 메시지를 보여준다", async () => {
+    const checkSpy = vi
+      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
+      .mockResolvedValue({
+        exists: true,
+      });
+
+    const wrapper = mount(SignupView);
+    await goToFormStep(wrapper);
+
+    await wrapper.find("#baekjoon-id").setValue("tourist");
+
+    const bjCheckBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("아이디 확인"));
+    expect(bjCheckBtn).toBeTruthy();
+
+    await bjCheckBtn.trigger("click");
+    await flushPromises();
+
+    expect(checkSpy).toHaveBeenCalledWith({ handle: "tourist" });
+    expect(wrapper.text()).toContain("존재하는 백준 아이디입니다.");
+  });
+
+  it("백준 아이디 확인 시 존재하지 않는 아이디면 경고 메시지를 보여준다", async () => {
+    const checkSpy = vi
+      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
+      .mockResolvedValue({
+        exists: false,
+      });
+
+    const wrapper = mount(SignupView);
+    await goToFormStep(wrapper);
+
+    await wrapper.find("#baekjoon-id").setValue("no_such_user_123");
+
+    const bjCheckBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("아이디 확인"));
+    expect(bjCheckBtn).toBeTruthy();
+
+    await bjCheckBtn.trigger("click");
+    await flushPromises();
+
+    expect(checkSpy).toHaveBeenCalledWith({ handle: "no_such_user_123" });
+    expect(wrapper.text()).toContain(
+      "존재하지 않는 백준 아이디입니다. 다시 확인해주세요.",
+    );
   });
 
   it("닉네임 중복 확인 버튼 클릭 시 mockCheckUsernameDuplicate를 호출하고 사용 가능 메시지를 보여준다", async () => {
@@ -135,6 +263,7 @@ describe("SignupView", () => {
     await goToFormStep(wrapper);
 
     await wrapper.find("#signup-email").setValue("dup@example.com");
+    await wrapper.find("#baekjoon-id").setValue("tourist");
     await wrapper.find("#nickname").setValue("dupUser");
 
     const nicknameCheckButton = wrapper
@@ -156,6 +285,7 @@ describe("SignupView", () => {
     await flushPromises();
 
     expect(signupSpy).not.toHaveBeenCalled();
+    // 닉네임 경고 메시지는 여전히 화면 상에 존재해야 함
     expect(wrapper.text()).toContain(
       "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.",
     );


### PR DESCRIPTION
이슈 번호 : https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/20
---
## 🔍 먼저 보면 좋은 포인트

1. **스코프**

   * *오직* **백준 아이디(baekjoonId)** 관련 기능만 건드립니다.
   * 영향 범위: `authApi/mockAuthApi` + `SignupView` + `MyPageView` + 해당 테스트.

2. **위험도**

   * 로그인/회원가입 기존 플로우는 그대로 유지하면서,
     그 위에 **Baekjoon 필드/검증 한 층 덧댄 수준**입니다.
   * 실제 서버는 아직 붙지 않았고, **mock 기반**으로 동작합니다.

3. **리뷰할 때 집중할 곳**

   * **API 레이어 인터페이스**
     `verifyBaekjoonId`, `updateBaekjoonId`, `mockCheckBaekjoonId`, `mockUpdateBaekjoonId`
     → 나중에 BE가 구현할 실제 엔드포인트와 맞출 수 있는 구조인지.
   * **검증 UX 흐름**
     “입력 → 아이디 확인 버튼 → 유효성 통과 후만 저장 허용” 플로우가 직관적인지.
   * **마이페이지 동작**
     비밀번호 인증 후 백준 아이디 수정/저장 로직이 자연스러운지.

---

## ✅ 이 PR에서 구현한 내용 (What & Why)

* **사용자 계정에 백준 아이디를 1:1로 연결하는 기능을 추가했습니다.**

  * 백준 아이디는 이후 **알고리즘 기록·난이도·추천 문제 등 핵심 기능의 키**가 되기 때문에,
  * 회원가입 시 최초 등록 + 마이페이지에서 수정 가능한 플로우를 미리 구축했습니다.

* **회원가입(Signup)에 ‘백준 아이디 입력 + 존재 여부 검증’ 단계를 넣었습니다.**

  * 사용자가 임의의 문자열을 넣는 것이 아니라,
    **실제로 존재하는 백준 아이디만 저장되도록 강제**합니다.
  * “아이디 확인” 버튼을 눌러야만 회원가입이 가능하고,
    존재하지 않는 아이디면 가입을 막습니다.

* **마이페이지(MyPage)에서 백준 아이디를 조회·수정·저장할 수 있게 했습니다.**

  * 비밀번호 검증 후:

    * 기존에 등록된 백준 아이디를 가져와 보여주고,
    * 새 아이디로 변경 시 다시 “존재 여부 검증 → 저장” 플로우를 거치게 했습니다.

* **모든 동작은 현재 mock 기반으로 동작하며, 향후 실제 API로 교체 가능한 인터페이스를 미리 맞춰두었습니다.**

---

## 📂 변경된 주요 컴포넌트/모듈 (Where)

### 1) API & Mock

* `src/api/authApi.js`

  * `verifyBaekjoonId({ handle })`

    * (향후) `/v1/baekjoon/verify?handle=...` 호출을 감싸는 래퍼.
  * `updateBaekjoonId({ baekjoonId })`

    * (향후) `/v1/members/me/baekjoon-id` PATCH를 감싸는 래퍼.

* `src/api/mockAuthApi.js`

  * `mockCheckBaekjoonId({ handle })`

    * 간단 규칙 기반 mock:

      * `"unknown"`, `"notfound"`, `"invalid"` → `exists: false`
      * 그 외 문자열 → `exists: true`
  * `mockSignup({ email, nickname, password, baekjoonId })`

    * mock 유저 생성 시 `baekjoonId` 필드를 포함.
  * `mockVerifyPassword({ password })`

    * 반환되는 `user`에 `baekjoonId`를 추가.
  * `mockUpdateBaekjoonId({ baekjoonId })`

    * `localStorage` 내 currentUser 및 users 배열의 `baekjoonId`를 모두 갱신.
    * 로그인 X, 유저 없음 등은 코드(`NOT_LOGGED_IN`, `USER_NOT_FOUND`)로 구분.

### 2) 뷰

* `src/views/SignupView.vue`

  * 회원가입 폼에 **백준 아이디 입력 필드 + ‘아이디 확인’ 버튼** 추가.
  * 상태:

    * `baekjoonId`, `isBaekjoonValid`, `baekjoonCheckMessage`, `isCheckingBaekjoonId` 등.
  * 검증:

    * 공백이면: “백준 아이디를 입력해주세요.”
    * `아이디 확인` 버튼을 눌러 `isBaekjoonValid === true` 가 되어야만 submit 허용.

* `src/views/MyPageView.vue`

  * 프로필 섹션에 **백준 아이디 표시/수정 UI** 추가.
  * 상태:

    * `baekjoonId`, `originalBaekjoonId`,
      `isEditingBaekjoonId`, `isCheckingBaekjoonId`, `isSavingBaekjoonId`,
      `isBaekjoonValid`, `baekjoonCheckMessage`.
  * 비밀번호 검증 성공 시:

    * 서버(현재는 mock)에서 내려온 `baekjoonId`를 함께 세팅.

### 3) 테스트

* `tests/SignupView.spec.js`

  * 약관 단계 통과 후:

    * 백준 아이디를 비우고 제출하면 에러 메시지 나오는지.
    * ‘아이디 확인’ 버튼을 눌러야 검증 상태가 true가 되는지.
    * `mockCheckBaekjoonId` 호출 여부 및 메시지 변화 확인.

* `tests/MyPageView.spec.js`

  * 비밀번호 검증 시 `baekjoonId`까지 세팅되는지.
  * 백준 아이디 수정에서:

    * 공백/미검증 상태에서 저장을 막는지.
    * 기존 값과 동일한 경우 불필요한 API 호출이 일어나지 않는지.
    * `mockUpdateBaekjoonId` 호출 후 상태 업데이트가 올바른지.

---

## 🧪 동작 흐름/사용 시나리오 (How)

### 1) 회원가입 시

1. 사용자가 약관 동의 후 회원가입 폼으로 진입한다.
2. `이메일`, `백준 아이디`, `닉네임`, `비밀번호` 등을 입력한다.
3. **백준 아이디 옆 ‘아이디 확인’ 버튼 클릭**

   * 입력이 비어 있으면:
     → “백준 아이디를 먼저 입력해주세요.”
   * 입력이 있으면:
     → `mockCheckBaekjoonId({ handle })` 호출
     → 존재하면 초록 메시지 + `isBaekjoonValid = true`
     → 없으면 빨간 메시지 + `isBaekjoonValid = false`
4. **회원가입 버튼 클릭**

   * 일반 폼 검증 +
   * `baekjoonId` 비어있지 않고, `isBaekjoonValid === true` 일 때만 진행.
   * 조건을 만족하면 `mockSignup({ ..., baekjoonId })` 호출 후 기존 플로우대로 진행.

### 2) 마이페이지에서 백준 아이디 수정

1. 마이페이지 진입 후 **현재 비밀번호 검증**을 통과한다.
2. 반환된 `user` 정보에서 `baekjoonId`를 가져와 화면에 표시한다.
3. `수정` 클릭 → 수정 모드 진입.
4. 새 백준 아이디 입력 후 `아이디 확인` 버튼 클릭:

   * 공백 → “백준 아이디를 먼저 입력해주세요.”
   * 기존 값과 동일 → API 호출 없이 “현재 등록된 백준 아이디입니다.”, `isBaekjoonValid = true`.
   * 변경된 값 → `mockCheckBaekjoonId`로 존재 여부 확인.
5. `저장` 클릭:

   * 공백 → “백준 아이디를 비울 수 없습니다.”
   * `isBaekjoonValid !== true` → “백준 아이디가 실제로 존재하는지 확인 버튼을 눌러주세요.”
   * 위 조건 통과 시:

     * `mockUpdateBaekjoonId({ baekjoonId })` 호출
     * 로컬 상태/원본 값 갱신, 수정 모드 종료
     * “백준 아이디가 변경되었습니다.” 메시지 표시
     * `authStore.fetchCurrentUser({ force: true })` 로 헤더 등 전역 상태 동기화

---

## 💡 기타 (Risk / Rollout / Follow-up)

* **Risk**

  * 현재는 mock만 사용하므로,
    실 서버 연동 시 **응답 스키마 차이**가 가장 큰 리스크입니다.
  * 특히:

    * `verifyBaekjoonId`의 `{ exists: boolean }`
    * `updateBaekjoonId` 이후 반환되는 `user` 객체 구조
      를 백엔드와 합의할 필요가 있습니다.

* **Rollout**

  * FE 레이어는 이미 **“실제 API가 바로 들어올 수 있는 구조”**로 작성해 두었습니다.
  * BE 구현 이후에는:

    * `authApi.verifyBaekjoonId`, `updateBaekjoonId`를 실제 엔드포인트로 연결
    * mock 호출 부분만 실제 API로 교체
    * 기존 테스트를 BE 스키마에 맞게 약간 수정

* **Follow-up 아이디어**

  * `verifyBaekjoonId` 응답에 `tier`, `solvedCount` 등 메타 데이터를 추가받으면,

    * 회원가입/마이페이지에서 사용자에게 **기본 티어/푼 문제 수**를 바로 보여줄 수 있음.
  * 백준 아이디 변경을 트리거로,
    **그룹 보드 추천·난이도 조정 로직**까지 이어지는 후속 기능을 설계할 수 있음.

---
