### PR TITLE
[BSM-24] refactor: introduce authService and decouple authStore from mocks

### DIFF
--- a/src/data/authStore.js
+++ b/src/data/authStore.js
@@ -1,17 +1,5 @@
-// - 지금은 mockAuthApi 기반으로 동작
-// - 나중에 실제 백엔드(/auth/login, /members/me 등) 붙일 때는
-//   아래 TODO 부분만 바꿔주면 됨
-
 import { reactive, computed, readonly } from "vue";
-// TODO: 실제 백엔드 붙일 때 사용
-import { loginWithIdPw, logout as apiLogout } from "@/api/authApi";
-
-// 지금은 mock 기반
-import { mockLogin, mockLogout, mockGetCurrentUser } from "@/mocks/auth.mock";
-
-// 나중에는 .env로 빼서 제어하는 게 베스트:
-// const USE_MOCK_AUTH = import.meta.env.VITE_USE_MOCK_AUTH === "true";
-const USE_MOCK_AUTH = true;
+import { authService } from "@/services/authService";
 
 const state = reactive({
   user: null, // { id, email, nickname, ... }
@@ -32,29 +20,13 @@ function clearUser() {
 /**
  * 로그인
  * @param {{ id: string, password: string }} credentials
- *   - mock: id를 email로 사용
- *   - 실제: 백엔드 규칙대로 id/email 중 하나
  */
 async function login(credentials) {
   state.isLoading = true;
   state.error = null;
 
   try {
-    let user;
-
-    if (USE_MOCK_AUTH) {
-      // ===== 지금: mock 로그인 (email + password) =====
-      const { user: mockUser } = await mockLogin({
-        email: credentials.id,
-        password: credentials.password,
-      });
-      user = mockUser;
-    } else {
-      // ===== 나중: 실제 백엔드 로그인 =====
-      const data = await loginWithIdPw(credentials);
-      user = data.user ?? data;
-    }
-
+    const user = await authService.login(credentials);
     setUser(user);
     return user;
   } catch (err) {
@@ -74,8 +46,6 @@ async function login(credentials) {
 /**
  * 현재 로그인 사용자 동기화
  * - 앱 첫 로딩 / 새로고침 이후에 호출
- * - 실제 서비스에서는 /members/me 같은 API를 쓰고,
- *   지금은 mockGetCurrentUser(localStorage)로 대체
  */
 async function fetchCurrentUser({ force = false } = {}) {
   if (state.initialized && !force) return;
@@ -84,17 +54,7 @@ async function fetchCurrentUser({ force = false } = {}) {
   state.error = null;
 
   try {
-    let user = null;
-
-    if (USE_MOCK_AUTH) {
-      // mock: localStorage에서 복원
-      user = mockGetCurrentUser();
-    } else {
-      // 실제: /members/me 등에서 가져오기
-      // const me = await getMyProfile();
-      // user = me;
-    }
-
+    const user = await authService.fetchCurrentUser();
     setUser(user);
   } catch (err) {
     console.error("[authStore] fetchCurrentUser error:", err);
@@ -113,11 +73,7 @@ async function logout() {
   state.error = null;
 
   try {
-    if (USE_MOCK_AUTH) {
-      mockLogout();
-    } else {
-      await apiLogout();
-    }
+    await authService.logout();
   } catch (err) {
     console.error("[authStore] logout error:", err);
   } finally {

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,54 @@
+import { apiMode } from "@/config/apiMode";
+import { loginWithIdPw, logout as apiLogout } from "@/api/authApi";
+import { mockLogin, mockLogout, mockGetCurrentUser } from "@/mocks/auth.mock";
+
+const USE_MOCK_AUTH = apiMode.auth === "mock";
+
+export const authService = {
+  /**
+   * 로그인
+   * @param {{ id: string, password: string }} credentials
+   */
+  async login({ id, password }) {
+    if (USE_MOCK_AUTH) {
+      // mock: email + password 기반
+      const { user: mockUser } = await mockLogin({
+        email: id,
+        password,
+      });
+      return mockUser;
+    }
+
+    // real: 백엔드 /auth/login
+    const data = await loginWithIdPw({ id, password });
+    return data.user ?? data;
+  },
+
+  /**
+   * 현재 로그인 사용자 조회
+   * - mock: localStorage 기반
+   * - real: 추후 /members/me 등으로 교체 예정
+   */
+  async fetchCurrentUser() {
+    if (USE_MOCK_AUTH) {
+      return mockGetCurrentUser();
+    }
+
+    // TODO: 백엔드에서 /members/me 준비되면 아래 구현
+    // const me = await getMyProfile();
+    // return me;
+    return null;
+  },
+
+  /**
+   * 로그아웃
+   */
+  async logout() {
+    if (USE_MOCK_AUTH) {
+      mockLogout();
+      return;
+    }
+
+    await apiLogout();
+  },
+};


### PR DESCRIPTION
이슈번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/24
---

## ✅ 변경 내용

- `authService`를 새로 도입해 auth 도메인의 mock/real 분기를 service 레이어에서 처리하도록 했습니다.
- `authStore`는 더 이상 mock/real 여부를 알지 않고, `authService`만 호출하도록 리팩토링했습니다.
  - `USE_MOCK_AUTH` 플래그 제거
  - `mockLogin`, `mockLogout`, `mockGetCurrentUser` 직접 사용 제거
- 현재는 `apiMode.auth === "mock"` 기준으로 mock 로그인 플로우를 사용하며, 동작은 기존과 동일합니다.

## 📂 주요 변경 파일

- `src/services/authService.js` (신규)
- `src/data/authStore.js` (mock/real 분기 제거 및 service 사용)

## 🔍 리뷰 포인트

- `authService`의 mock/real 분기 로직이 직관적인지
- `authStore`에서 인증 관련 책임이 적절히 service로 위임되었는지
- 리팩토링 후에도 로그인/로그아웃/세션 복원이 기존과 동일하게 동작하는지

## 🧪 테스트

- [x] mock 계정으로 로그인 시 정상 로그인
- [x] 잘못된 계정 로그인 시 에러 메시지 노출
- [x] 새로고침 후 세션 복원 (`fetchCurrentUser`)
- [x] 로그아웃 후 인증 정보 초기화