### PR TITLE
[BSM-26] refactor: extract board mocks and introduce boardService, boardApi skeleton

### DIFF
--- a/src/api/boardApi.js
+++ b/src/api/boardApi.js
@@ -1,20 +1,57 @@
 import httpClient from "./httpClient";
 
-// 방금 만든 목업 API
-import { mockGetBoardUserStatus } from "@/mocks/boardUserStatus.mock";
+/**
+ * 그룹 ID에 해당하는 보드 목록 조회
+ * GET /v1/groups/{groupId}/boards
+ */
+export async function fetchBoards(groupId) {
+  const res = await httpClient.get(`/v1/groups/${groupId}/boards`);
+  return res.data;
+}
 
-// 나중에 .env로 빼면 더 좋음
-const USE_MOCK = true;
+/**
+ * 특정 보드 상세 조회
+ * GET /v1/boards/{boardId}
+ */
+export async function fetchBoardById(boardId) {
+  const res = await httpClient.get(`/v1/boards/${boardId}`);
+  return res.data;
+}
 
+/**
+ * 보드 생성
+ * POST /v1/boards
+ */
+export async function createBoard(payload) {
+  const res = await httpClient.post("/v1/boards", payload);
+  return res.data;
+}
+
+/**
+ * 보드 수정
+ * PUT /v1/boards/{boardId}
+ */
+export async function updateBoard(boardId, payload) {
+  const res = await httpClient.put(`/v1/boards/${boardId}`, payload);
+  return res.data;
+}
+
+/**
+ * 보드 삭제
+ * DELETE /v1/boards/{boardId}
+ */
+export async function deleteBoard(boardId) {
+  const res = await httpClient.delete(`/v1/boards/${boardId}`);
+  return res.data;
+}
+
+/**
+ * 보드별 유저 풀이 현황
+ * GET /v1/groups/{groupId}/boards/{boardId}/userStatus
+ */
 export async function getBoardUserStatus(groupId, boardId) {
-  if (USE_MOCK) {
-    // ✅ 지금은 목업 데이터 반환
-    return mockGetBoardUserStatus(groupId, boardId);
-  }
-
-  // 🔜 실제 백엔드 붙일 때는 여기만 살리면 됨
   const res = await httpClient.get(
-    `/api/v1/groups/${groupId}/boards/${boardId}/userStatus`,
+    `/v1/groups/${groupId}/boards/${boardId}/userStatus`,
   );
   return res.data;
 }

--- a/src/data/boardStore.js
+++ b/src/data/boardStore.js
@@ -1,156 +1,60 @@
 import { ref } from "vue";
-import { MOCK_PROBLEMS } from "/src/api/problemApi";
+import { boardService } from "../services/boardService";
 
-export const boards = ref([]); // 처음엔 빈 배열
-
-// [테스트용 날짜 생성 함수]
-const getDateStr = (diffDays) => {
-  const date = new Date();
-  date.setDate(date.getDate() + diffDays);
-  return date.toISOString().split(".")[0];
-  // return date.toISOString().split("T")[0];
-};
-
-const MOCK_DB_DATA_WITH_PROBLEMS = [
-  {
-    id: 1,
-    groupId: 1,
-    title: "Vue.js 프론트엔드 뽀개기",
-    deadline: getDateStr(7),
-    problems: [MOCK_PROBLEMS[0], MOCK_PROBLEMS[1], MOCK_PROBLEMS[2]],
-    problemsCount: 3,
-  },
-  {
-    id: 2,
-    groupId: 1,
-    title: "알고리즘 코딩테스트 대비반",
-    deadline: getDateStr(30),
-    problems: [
-      MOCK_PROBLEMS[3],
-      MOCK_PROBLEMS[4],
-      MOCK_PROBLEMS[5],
-      MOCK_PROBLEMS[6],
-    ],
-    problemsCount: 4,
-  },
-  {
-    id: 3,
-    groupId: 2,
-    title: "자유 주제 아이디어 보드",
-    deadline: null,
-    problems: [MOCK_PROBLEMS[7], MOCK_PROBLEMS[8], MOCK_PROBLEMS[9]],
-    problemsCount: 3,
-  },
-  {
-    id: 4,
-    groupId: 2,
-    title: "2023년 상반기 회고",
-    deadline: getDateStr(-100),
-    problems: [MOCK_PROBLEMS[10], MOCK_PROBLEMS[11]],
-    problemsCount: 2,
-  },
-  {
-    id: 5,
-    groupId: 3,
-    title: "지난주 CS 스터디 (네트워크)",
-    deadline: getDateStr(-3),
-    problems: [MOCK_PROBLEMS[12]],
-    problemsCount: 1,
-  },
-  {
-    id: 6,
-    groupId: 3,
-    title: "사내 해커톤 프로젝트",
-    deadline: getDateStr(1),
-    problems: [],
-    problemsCount: 0,
-  },
-  {
-    id: 7,
-    groupId: 1,
-    title: "리액트 vs 뷰 비교 분석",
-    deadline: getDateStr(-1),
-    problems: [MOCK_PROBLEMS[12], MOCK_PROBLEMS[13]],
-    problemsCount: 2,
-  },
-];
-
-const LOCAL_DB = ref(MOCK_DB_DATA_WITH_PROBLEMS);
-
-// --- Actions (API 호출 함수) ---
+export const boards = ref([]);
 
 /**
- * GET /api/v1/groups/{groupsId}/
  * 그룹 ID에 해당하는 보드 목록을 가져옵니다.
  */
 export async function fetchBoards(groupId) {
-  // 실제 API 호출이라면 아래와 같을 것입니다:
-  // const response = await axios.get(`/api/v1/groups/${groupId}/`);
-  // boards.value = response.data;
-
-  const numericGroupId = Number(groupId);
-  // [Mocking] 0.5초 뒤에 데이터를 받아온 척 합니다.
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      console.log(`[API Mock] 그룹 ID ${numericGroupId}의 보드 목록 조회 성공`);
-      boards.value = LOCAL_DB.value.filter((b) => b.groupId === numericGroupId);
-      resolve(boards.value);
-    }, 500); // 0.5초 딜레이
-  });
-}
-
-export function addBoard(board) {
-  if (!board.id) board.id = Date.now();
-  // 🚨 problemsCount를 problems 배열의 길이로 설정
-  const newBoard = {
-    ...board,
-    problemsCount: board.problems ? board.problems.length : 0,
-  };
-  LOCAL_DB.value = [newBoard, ...LOCAL_DB.value];
-  console.log("새 보드 추가 완료. LOCAL_DB에 반영됨.");
-}
-
-export function deleteBoard(id) {
-  LOCAL_DB.value = LOCAL_DB.value.filter((board) => board.id !== id);
-  // 실제론: await axios.delete(`/api/v1/boards/${id}`);
+  const list = await boardService.fetchBoards(groupId);
+  boards.value = [...list];
+  return boards.value;
 }
 
 /**
- * PUT /api/v1/boards/{boardId}
- * 보드를 수정하고 localDB에 반영합니다.
+ * 새 보드를 추가합니다.
+ * - 기존 addBoard 이름을 유지 (호출부 영향 최소화)
  */
-export function updateBoard(updatedBoard) {
-  const index = LOCAL_DB.value.findIndex((b) => b.id == updatedBoard.id);
+export async function addBoard(board) {
+  const newBoard = await boardService.createBoard(board);
+  boards.value = [newBoard, ...boards.value];
+  return newBoard;
+}
+
+/**
+ * 보드를 삭제합니다.
+ */
+export async function deleteBoard(boardId) {
+  await boardService.deleteBoard(boardId);
+  const numericId = Number(boardId);
+  boards.value = boards.value.filter((b) => b.id !== numericId);
+}
+
+/**
+ * 보드를 수정합니다.
+ */
+export async function updateBoard(updatedBoard) {
+  const updated = await boardService.updateBoard(updatedBoard);
+
+  const index = boards.value.findIndex((b) => b.id == updated.id);
   if (index !== -1) {
-    LOCAL_DB.value[index] = {
-      ...LOCAL_DB.value[index],
-      ...updatedBoard,
-      problemsCount: updatedBoard.problems ? updatedBoard.problems.length : 0,
-    };
-    console.log(`[Mock DB] 보드 ID ${updatedBoard.id} 수정 완료.`);
-  } else {
-    console.error(
-      `수정할 보드 ID ${updatedBoard.id}를 localDB에서 찾을 수 없습니다.`,
-    );
+    boards.value.splice(index, 1, updated);
   }
+
+  return updated;
 }
 
 /**
- * GET /api/v1/boards/{boardId}
- * 특정 보드의 상세 정보를 가져옵니다. (Mocking)
+ * 특정 보드의 상세 정보를 가져옵니다.
  */
-export async function fetchBoardById(id) {
-  const board = LOCAL_DB.value.find((b) => b.id == id);
+export async function fetchBoardById(boardId) {
+  return boardService.fetchBoardById(boardId);
+}
 
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      if (board) {
-        console.log(`[API Mock] 보드 ID ${id}의 상세 정보 조회 성공`);
-        resolve(board);
-      } else {
-        console.error(`[API Mock] 보드 ID ${id}를 찾을 수 없습니다.`);
-        reject(new Error("Board Not Found"));
-      }
-    }, 300);
-  });
+/**
+ * 보드별 유저 풀이 현황 조회
+ */
+export async function getBoardUserStatus(groupId, boardId) {
+  return boardService.getBoardUserStatus(groupId, boardId);
 }

--- a/src/mocks/board.mock.js
+++ b/src/mocks/board.mock.js
@@ -139,7 +139,7 @@ export function mockUpdateBoard(updatedBoard) {
  * GET /api/v1/boards/{boardId}
  * 특정 보드의 상세 정보를 가져옵니다. (Mocking)
  */
-export async function fetchBoardById(id) {
+export async function mockFetchBoardById(id) {
   const board = LOCAL_DB.value.find((b) => b.id == id);
 
   return new Promise((resolve, reject) => {

--- a/src/mocks/board.mock.js
+++ b/src/mocks/board.mock.js
@@ -1,0 +1,156 @@
+import { ref } from "vue";
+import { MOCK_PROBLEMS } from "/src/api/problemApi";
+
+export const boards = ref([]); // 처음엔 빈 배열
+
+// [테스트용 날짜 생성 함수]
+const getDateStr = (diffDays) => {
+  const date = new Date();
+  date.setDate(date.getDate() + diffDays);
+  return date.toISOString().split(".")[0];
+  // return date.toISOString().split("T")[0];
+};
+
+const MOCK_DB_DATA_WITH_PROBLEMS = [
+  {
+    id: 1,
+    groupId: 1,
+    title: "Vue.js 프론트엔드 뽀개기",
+    deadline: getDateStr(7),
+    problems: [MOCK_PROBLEMS[0], MOCK_PROBLEMS[1], MOCK_PROBLEMS[2]],
+    problemsCount: 3,
+  },
+  {
+    id: 2,
+    groupId: 1,
+    title: "알고리즘 코딩테스트 대비반",
+    deadline: getDateStr(30),
+    problems: [
+      MOCK_PROBLEMS[3],
+      MOCK_PROBLEMS[4],
+      MOCK_PROBLEMS[5],
+      MOCK_PROBLEMS[6],
+    ],
+    problemsCount: 4,
+  },
+  {
+    id: 3,
+    groupId: 2,
+    title: "자유 주제 아이디어 보드",
+    deadline: null,
+    problems: [MOCK_PROBLEMS[7], MOCK_PROBLEMS[8], MOCK_PROBLEMS[9]],
+    problemsCount: 3,
+  },
+  {
+    id: 4,
+    groupId: 2,
+    title: "2023년 상반기 회고",
+    deadline: getDateStr(-100),
+    problems: [MOCK_PROBLEMS[10], MOCK_PROBLEMS[11]],
+    problemsCount: 2,
+  },
+  {
+    id: 5,
+    groupId: 3,
+    title: "지난주 CS 스터디 (네트워크)",
+    deadline: getDateStr(-3),
+    problems: [MOCK_PROBLEMS[12]],
+    problemsCount: 1,
+  },
+  {
+    id: 6,
+    groupId: 3,
+    title: "사내 해커톤 프로젝트",
+    deadline: getDateStr(1),
+    problems: [],
+    problemsCount: 0,
+  },
+  {
+    id: 7,
+    groupId: 1,
+    title: "리액트 vs 뷰 비교 분석",
+    deadline: getDateStr(-1),
+    problems: [MOCK_PROBLEMS[12], MOCK_PROBLEMS[13]],
+    problemsCount: 2,
+  },
+];
+
+const LOCAL_DB = ref(MOCK_DB_DATA_WITH_PROBLEMS);
+
+// --- Actions (API 호출 함수) ---
+
+/**
+ * GET /api/v1/groups/{groupsId}/
+ * 그룹 ID에 해당하는 보드 목록을 가져옵니다.
+ */
+export async function mockFetchBoards(groupId) {
+  // 실제 API 호출이라면 아래와 같을 것입니다:
+  // const response = await axios.get(`/api/v1/groups/${groupId}/`);
+  // boards.value = response.data;
+
+  const numericGroupId = Number(groupId);
+  // [Mocking] 0.5초 뒤에 데이터를 받아온 척 합니다.
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      console.log(`[API Mock] 그룹 ID ${numericGroupId}의 보드 목록 조회 성공`);
+      boards.value = LOCAL_DB.value.filter((b) => b.groupId === numericGroupId);
+      resolve(boards.value);
+    }, 500); // 0.5초 딜레이
+  });
+}
+
+export function mockCreateBoard(board) {
+  if (!board.id) board.id = Date.now();
+  // 🚨 problemsCount를 problems 배열의 길이로 설정
+  const newBoard = {
+    ...board,
+    problemsCount: board.problems ? board.problems.length : 0,
+  };
+  LOCAL_DB.value = [newBoard, ...LOCAL_DB.value];
+  console.log("새 보드 추가 완료. LOCAL_DB에 반영됨.");
+}
+
+export function mockDeleteBoard(id) {
+  LOCAL_DB.value = LOCAL_DB.value.filter((board) => board.id !== id);
+  // 실제론: await axios.delete(`/api/v1/boards/${id}`);
+}
+
+/**
+ * PUT /api/v1/boards/{boardId}
+ * 보드를 수정하고 localDB에 반영합니다.
+ */
+export function mockUpdateBoard(updatedBoard) {
+  const index = LOCAL_DB.value.findIndex((b) => b.id == updatedBoard.id);
+  if (index !== -1) {
+    LOCAL_DB.value[index] = {
+      ...LOCAL_DB.value[index],
+      ...updatedBoard,
+      problemsCount: updatedBoard.problems ? updatedBoard.problems.length : 0,
+    };
+    console.log(`[Mock DB] 보드 ID ${updatedBoard.id} 수정 완료.`);
+  } else {
+    console.error(
+      `수정할 보드 ID ${updatedBoard.id}를 localDB에서 찾을 수 없습니다.`,
+    );
+  }
+}
+
+/**
+ * GET /api/v1/boards/{boardId}
+ * 특정 보드의 상세 정보를 가져옵니다. (Mocking)
+ */
+export async function fetchBoardById(id) {
+  const board = LOCAL_DB.value.find((b) => b.id == id);
+
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (board) {
+        console.log(`[API Mock] 보드 ID ${id}의 상세 정보 조회 성공`);
+        resolve(board);
+      } else {
+        console.error(`[API Mock] 보드 ID ${id}를 찾을 수 없습니다.`);
+        reject(new Error("Board Not Found"));
+      }
+    }, 300);
+  });
+}

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -1,0 +1,58 @@
+// src/services/boardService.js
+import { apiMode } from "@/config/apiMode";
+import * as boardApi from "@/api/boardApi";
+import {
+  mockFetchBoards,
+  mockFetchBoardById,
+  mockCreateBoard,
+  mockUpdateBoard,
+  mockDeleteBoard,
+} from "@/mocks/board.mock";
+import { mockGetBoardUserStatus } from "@/mocks/boardUserStatus.mock";
+
+const USE_MOCK_BOARD = apiMode.board === "mock";
+
+export const boardService = {
+  async fetchBoards(groupId) {
+    if (USE_MOCK_BOARD) {
+      return mockFetchBoards(groupId);
+    }
+    return boardApi.fetchBoards(groupId);
+  },
+
+  async fetchBoardById(boardId) {
+    if (USE_MOCK_BOARD) {
+      return mockFetchBoardById(boardId);
+    }
+    return boardApi.fetchBoardById(boardId);
+  },
+
+  async createBoard(board) {
+    if (USE_MOCK_BOARD) {
+      return mockCreateBoard(board);
+    }
+    return boardApi.createBoard(board);
+  },
+
+  async updateBoard(updatedBoard) {
+    if (USE_MOCK_BOARD) {
+      return mockUpdateBoard(updatedBoard);
+    }
+    const { id, ...payload } = updatedBoard;
+    return boardApi.updateBoard(id, payload);
+  },
+
+  async deleteBoard(boardId) {
+    if (USE_MOCK_BOARD) {
+      return mockDeleteBoard(boardId);
+    }
+    return boardApi.deleteBoard(boardId);
+  },
+
+  async getBoardUserStatus(groupId, boardId) {
+    if (USE_MOCK_BOARD) {
+      return mockGetBoardUserStatus(groupId, boardId);
+    }
+    return boardApi.getBoardUserStatus(groupId, boardId);
+  },
+};

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -1,4 +1,3 @@
-// src/services/boardService.js
 import { apiMode } from "@/config/apiMode";
 import * as boardApi from "@/api/boardApi";
 import {

--- a/src/views/BoardDetailView.vue
+++ b/src/views/BoardDetailView.vue
@@ -5,7 +5,7 @@ import { useAuthStore } from "../data/authStore";
 import { fetchBoardById } from "../data/boardStore";
 import { fetchGroupById } from "../data/groupStore";
 import { members } from "../data/memberStore";
-import { getBoardUserStatus } from "../api/boardApi";
+import { getBoardUserStatus } from "@/data/boardStore";
 
 const route = useRoute();
 const router = useRouter();

--- a/tests/BoardDetailView.spec.js
+++ b/tests/BoardDetailView.spec.js
@@ -58,15 +58,12 @@ vi.mock("@/data/groupStore", () => {
 // =======================
 vi.mock("@/data/boardStore", () => {
   const fetchBoardById = vi.fn();
-  return { fetchBoardById };
-});
-
-// =======================
-// 6) boardApi mock
-// =======================
-vi.mock("@/api/boardApi", () => {
   const getBoardUserStatus = vi.fn();
-  return { getBoardUserStatus };
+
+  return {
+    fetchBoardById,
+    getBoardUserStatus,
+  };
 });
 
 // =======================
@@ -77,7 +74,7 @@ import { useAuthStore as useAuthStoreMock } from "@/data/authStore";
 import { members as membersRef } from "@/data/memberStore";
 import { fetchGroupById as fetchGroupByIdMock } from "@/data/groupStore";
 import { fetchBoardById as fetchBoardByIdMock } from "@/data/boardStore";
-import { getBoardUserStatus as getBoardUserStatusMock } from "@/api/boardApi";
+import { getBoardUserStatus as getBoardUserStatusMock } from "@/data/boardStore";
 
 // 공통 더미 데이터
 const sampleGroup = {


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/26
---
## ✅ 변경 내용

- `boardStore` 안에 섞여 있던 보드 mock DB 및 CRUD 로직을 `src/mocks/board.mock.js`로 분리했습니다.
- 보드별 유저 풀이 현황 mock을 `src/mocks/boardUserStatus.mock.js`로 정리했습니다.
- 실제 백엔드 연동을 위한 `src/api/boardApi.js` 골격을 추가/정리했습니다.
- `apiMode.board` 값을 기준으로 mock/real을 선택하는 `boardService`를 도입했습니다.
- `boardStore`는 상태(`boards`) 관리와 `boardService` 호출만 담당하도록 리팩토링했습니다.

## 📂 주요 변경 파일

- `src/mocks/board.mock.js` (신규, 기존 mock 로직 이동)
- `src/mocks/boardUserStatus.mock.js` (신규, 기존 mockBoardUserStatusApi 이동/정리)
- `src/api/boardApi.js` (실제 API 골격)
- `src/services/boardService.js` (mock/real 분기)
- `src/data/boardStore.js` (mock 제거 및 service 사용)

## 🔍 리뷰 포인트

- mock/real 분기(`boardService`) 구조가 직관적인지
- `boardStore`에서 상태 관리와 도메인 로직이 적절히 분리되었는지
- 리팩토링 후에도 보드 목록/상세/생성/수정/삭제, 유저 풀이 현황이 기존과 동일하게 동작하는지

## 🧪 테스트

- [x] 그룹별 보드 목록 조회
- [x] 보드 생성 후 리스트 반영
- [x] 보드 수정 후 리스트/상세 반영
- [x] 보드 삭제 후 리스트 제거
- [x] 보드 상세 화면에서 유저 풀이 현황 조회
