### PR TITLE
[BSM-27] refactor: extract problemApi mocks and introduce problemService

### DIFF
--- a/src/api/problemApi.js
+++ b/src/api/problemApi.js
@@ -1,187 +1,4 @@
-// 간단한 mock API 계층입니다.
-// 실제 서버 API 주소에 맞게 수정해서 사용할 수 있습니다.
-
-function delay(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-//TODO: dependency management
-export const MOCK_PROBLEMS = [
-  {
-    id: 1409,
-    title: "피보나치 수 1",
-    difficulty: "Gold 5",
-    tags: ["DP"],
-    acceptedUserCount: 1200,
-    registeredAt: "2024-11-01", // 🔹 등록일
-    reviewCount: 2, // 🔹 복습 횟수
-  },
-  {
-    id: 1508,
-    title: "DFS와 BFS",
-    difficulty: "Gold 4",
-    tags: ["Graph", "Breadth-first Search(BFS)", "DFS"],
-    acceptedUserCount: 3920,
-    registeredAt: "2024-11-02",
-    reviewCount: 1,
-  },
-  {
-    id: 1000,
-    title: "A+B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-03",
-    reviewCount: 0,
-  },
-  {
-    id: 1001,
-    title: "A-B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-04",
-    reviewCount: 3,
-  },
-  {
-    id: 1002,
-    title: "A*B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-05",
-    reviewCount: 1,
-  },
-  {
-    id: 1003,
-    title: "A/B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-06",
-    reviewCount: 0,
-  },
-  {
-    id: 1004,
-    title: "A%B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-07",
-    reviewCount: 2,
-  },
-  {
-    id: 1005,
-    title: "A&B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-08",
-    reviewCount: 4,
-  },
-  {
-    id: 1006,
-    title: "A|B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-09",
-    reviewCount: 0,
-  },
-  {
-    id: 1007,
-    title: "A^B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-10",
-    reviewCount: 2,
-  },
-  {
-    id: 1008,
-    title: "A@B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-11",
-    reviewCount: 1,
-  },
-  {
-    id: 1009,
-    title: "A#B",
-    difficulty: "Bronze 5",
-    tags: ["Implementation"],
-    acceptedUserCount: 99999,
-    registeredAt: "2024-11-12",
-    reviewCount: 5,
-  },
-  {
-    id: 2000,
-    title: "이분 탐색 기본",
-    difficulty: "Silver 3",
-    tags: ["Binary Search"],
-    acceptedUserCount: 8000,
-    registeredAt: "2024-11-13",
-    reviewCount: 0,
-  },
-  {
-    id: 2004,
-    title:
-      "이것은 세상에서 제일 긴 문제 이름입니다. 테스트를 위해서 이렇게 일단 만들었습니다. 과연 어떻게 나올 것인가",
-    difficulty: "Silver 3",
-    tags: ["Binary Search"],
-    acceptedUserCount: 8000,
-    registeredAt: "2024-11-14",
-    reviewCount: 2,
-  },
-];
-
-// 난이도 문자열을 순서 있는 숫자로 변환하기 위한 매핑
-// 앞에 있을수록 더 쉬운 난이도로 가정
-const DIFFICULTY_ORDER = [
-  "Bronze 5",
-  "Bronze 4",
-  "Bronze 3",
-  "Bronze 2",
-  "Bronze 1",
-  "Silver 5",
-  "Silver 4",
-  "Silver 3",
-  "Silver 2",
-  "Silver 1",
-  "Gold 5",
-  "Gold 4",
-  "Gold 3",
-  "Gold 2",
-  "Gold 1",
-  "Platinum 5",
-  "Platinum 4",
-  "Platinum 3",
-  "Platinum 2",
-  "Platinum 1",
-  "Diamond 5",
-  "Diamond 4",
-  "Diamond 3",
-  "Diamond 2",
-  "Diamond 1",
-  "Ruby 5",
-  "Ruby 4",
-  "Ruby 3",
-  "Ruby 2",
-  "Ruby 1",
-  "Master 5",
-  "Master 4",
-  "Master 3",
-  "Master 2",
-  "Master 1",
-  "Unrated",
-];
-
-function difficultyToIndex(value) {
-  if (value === undefined || value === null || value === "ALL") return null;
-  const idx = DIFFICULTY_ORDER.indexOf(value);
-  return idx === -1 ? null : idx;
-}
+import httpClient from "./httpClient";
 
 /**
  * 문제 번호로 검색
@@ -189,10 +6,10 @@ function difficultyToIndex(value) {
  * @returns {Promise<Array>}
  */
 export async function searchByNumber(problemNo) {
-  await delay(200);
   const num = Number(problemNo);
   if (!num) return [];
-  return MOCK_PROBLEMS.filter((p) => p.id === num);
+  const res = await httpClient.get(`/v1/problems/${num}`);
+  return Array.isArray(res.data) ? res.data : [res.data];
 }
 
 /**
@@ -210,81 +27,11 @@ export async function searchByNumber(problemNo) {
  * @returns {Promise<Array>}
  */
 export async function searchWithConditions(params = {}) {
-  await delay(200);
-
-  const {
-    difficulty, // 예전 방식: 단일 난이도
-    difficultyFrom, // 새 방식: 난이도 범위 시작
-    difficultyTo, // 새 방식: 난이도 범위 끝
-    tag,
-    minSolved,
-    beforeDate, // 🔹 등록일 필터
-    unsolvedOnly, // 🔹 미해결 필터 (mock에서는 사용 X)
-    aiRecommend, // 🔹 AI 추천 모드 (mock에서는 사용 X)
-  } = params;
-
-  const minDiffRaw = difficultyToIndex(difficultyFrom);
-  const maxDiffRaw = difficultyToIndex(difficultyTo);
-
-  const hasRange = minDiffRaw !== null || maxDiffRaw !== null;
-  const hasSingleDifficulty = !hasRange && difficulty && difficulty !== "ALL";
-
-  //TODO: use for api connection
-  unsolvedOnly;
-  aiRecommend;
-
-  return MOCK_PROBLEMS.filter((p) => {
-    // ===== 난이도 필터 =====
-    if (hasRange) {
-      const pd = difficultyToIndex(p.difficulty);
-      if (pd === null) return false;
-
-      let min = minDiffRaw;
-      let max = maxDiffRaw;
-
-      if (min !== null || max !== null) {
-        if (min === null) min = -Infinity;
-        if (max === null) max = Infinity;
-        if (min > max) {
-          const tmp = min;
-          min = max;
-          max = tmp;
-        }
-        if (pd < min || pd > max) return false;
-      }
-    } else if (hasSingleDifficulty) {
-      if (p.difficulty !== difficulty) return false;
-    }
-
-    // ===== 태그 필터 =====
-    if (
-      tag &&
-      String(tag).trim() &&
-      !p.tags.some((t) => t.toLowerCase().includes(String(tag).toLowerCase()))
-    ) {
-      return false;
-    }
-
-    // ===== 최소 해결자 수 필터 =====
-    if (typeof minSolved === "number" && !Number.isNaN(minSolved)) {
-      if (p.acceptedUserCount < minSolved) return false;
-    }
-
-    // ===== 날짜 필터 (beforeDate) =====
-    if (beforeDate) {
-      if (!p.registeredAt || p.registeredAt > beforeDate) {
-        return false;
-      }
-    }
-
-    // NOTE:
-    // unsolvedOnly, aiRecommend 는 실제 서버에서
-    //  - unsolvedOnly: 그룹/사용자 기준 미해결 문제만 필터링
-    //  - aiRecommend: AI 추천 알고리즘을 적용한 문제 목록 반환
-    // 에 사용된다고 가정하고, mock 에서는 별도 로직을 넣지 않습니다.
-
-    return true;
+  // 예시: GET /v1/problems/search?difficultyFrom=...&tag=...
+  const res = await httpClient.get("/v1/problems/search", {
+    params,
   });
+  return res.data;
 }
 
 /**
@@ -293,10 +40,6 @@ export async function searchWithConditions(params = {}) {
  * @returns {Promise<{success: boolean, received: any}>}
  */
 export async function postBoard(payload) {
-  await delay(300);
-  console.log("mock postBoard payload:", payload);
-  return {
-    success: true,
-    received: payload,
-  };
+  const res = await httpClient.post("/v1/boards", payload);
+  return res.data;
 }

--- a/src/components/ProblemBoard.vue
+++ b/src/components/ProblemBoard.vue
@@ -4,7 +4,7 @@ import { useRouter, useRoute } from "vue-router";
 import ProblemSearch from "./ProblemSearch.vue";
 import BoardHeader from "./board/BoardHeader.vue";
 import SelectedProblemsPanel from "./board/SelectedProblemsPanel.vue";
-import { postBoard } from "../api/problemApi";
+import { problemService } from "@/services/problemService";
 import {
   addBoard,
   updateBoard,
@@ -104,7 +104,7 @@ async function handlePost() {
     };
 
     // API 호출 (실제 백엔드는 payload를 저장)
-    const res = await postBoard(payload);
+    const res = await problemService.postBoard(payload);
     postResult.value = res;
 
     const groupId = Number(route.params.groupId);

--- a/src/components/ProblemSearch.vue
+++ b/src/components/ProblemSearch.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed } from "vue";
 import SearchFilters from "./search/SearchFilters.vue";
-import { searchWithConditions } from "../api/problemApi";
+import { problemService } from "@/services/problemService";
 
 const emit = defineEmits(["add-problem"]);
 
@@ -74,7 +74,7 @@ async function handleFiltersSearch(filter) {
 
     if (!hasAnyCondition) {
       // 조건이 하나도 없을 때: 기본 전체 검색
-      baseResults = await searchWithConditions({
+      baseResults = await problemService.searchWithConditions({
         difficultyFrom: undefined,
         difficultyTo: undefined,
         tag: "",
@@ -85,7 +85,7 @@ async function handleFiltersSearch(filter) {
       });
     } else if (hasProblemNo) {
       // 문제 번호를 입력한 경우: 번호 + 나머지 조건
-      const candidates = await searchWithConditions({
+      const candidates = await problemService.searchWithConditions({
         difficultyFrom: hasDifficultyRange ? filter.difficultyFrom : undefined,
         difficultyTo: hasDifficultyRange ? filter.difficultyTo : undefined,
         tag: "",
@@ -107,7 +107,7 @@ async function handleFiltersSearch(filter) {
       }
     } else {
       // 번호는 없고, 나머지 조건 검색
-      baseResults = await searchWithConditions({
+      baseResults = await problemService.searchWithConditions({
         difficultyFrom: hasDifficultyRange ? filter.difficultyFrom : undefined,
         difficultyTo: hasDifficultyRange ? filter.difficultyTo : undefined,
         tag: "",

--- a/src/mocks/board.mock.js
+++ b/src/mocks/board.mock.js
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import { MOCK_PROBLEMS } from "/src/api/problemApi";
+import { MOCK_PROBLEMS } from "@/mocks/problem.mock";
 
 export const boards = ref([]); // 처음엔 빈 배열
 

--- a/src/mocks/problem.mock.js
+++ b/src/mocks/problem.mock.js
@@ -1,0 +1,299 @@
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+//TODO: dependency management
+export const MOCK_PROBLEMS = [
+  {
+    id: 1409,
+    title: "피보나치 수 1",
+    difficulty: "Gold 5",
+    tags: ["DP"],
+    acceptedUserCount: 1200,
+    registeredAt: "2024-11-01", // 🔹 등록일
+    reviewCount: 2, // 🔹 복습 횟수
+  },
+  {
+    id: 1508,
+    title: "DFS와 BFS",
+    difficulty: "Gold 4",
+    tags: ["Graph", "Breadth-first Search(BFS)", "DFS"],
+    acceptedUserCount: 3920,
+    registeredAt: "2024-11-02",
+    reviewCount: 1,
+  },
+  {
+    id: 1000,
+    title: "A+B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-03",
+    reviewCount: 0,
+  },
+  {
+    id: 1001,
+    title: "A-B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-04",
+    reviewCount: 3,
+  },
+  {
+    id: 1002,
+    title: "A*B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-05",
+    reviewCount: 1,
+  },
+  {
+    id: 1003,
+    title: "A/B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-06",
+    reviewCount: 0,
+  },
+  {
+    id: 1004,
+    title: "A%B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-07",
+    reviewCount: 2,
+  },
+  {
+    id: 1005,
+    title: "A&B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-08",
+    reviewCount: 4,
+  },
+  {
+    id: 1006,
+    title: "A|B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-09",
+    reviewCount: 0,
+  },
+  {
+    id: 1007,
+    title: "A^B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-10",
+    reviewCount: 2,
+  },
+  {
+    id: 1008,
+    title: "A@B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-11",
+    reviewCount: 1,
+  },
+  {
+    id: 1009,
+    title: "A#B",
+    difficulty: "Bronze 5",
+    tags: ["Implementation"],
+    acceptedUserCount: 99999,
+    registeredAt: "2024-11-12",
+    reviewCount: 5,
+  },
+  {
+    id: 2000,
+    title: "이분 탐색 기본",
+    difficulty: "Silver 3",
+    tags: ["Binary Search"],
+    acceptedUserCount: 8000,
+    registeredAt: "2024-11-13",
+    reviewCount: 0,
+  },
+  {
+    id: 2004,
+    title:
+      "이것은 세상에서 제일 긴 문제 이름입니다. 테스트를 위해서 이렇게 일단 만들었습니다. 과연 어떻게 나올 것인가",
+    difficulty: "Silver 3",
+    tags: ["Binary Search"],
+    acceptedUserCount: 8000,
+    registeredAt: "2024-11-14",
+    reviewCount: 2,
+  },
+];
+
+// 난이도 문자열을 순서 있는 숫자로 변환하기 위한 매핑
+// 앞에 있을수록 더 쉬운 난이도로 가정
+const DIFFICULTY_ORDER = [
+  "Bronze 5",
+  "Bronze 4",
+  "Bronze 3",
+  "Bronze 2",
+  "Bronze 1",
+  "Silver 5",
+  "Silver 4",
+  "Silver 3",
+  "Silver 2",
+  "Silver 1",
+  "Gold 5",
+  "Gold 4",
+  "Gold 3",
+  "Gold 2",
+  "Gold 1",
+  "Platinum 5",
+  "Platinum 4",
+  "Platinum 3",
+  "Platinum 2",
+  "Platinum 1",
+  "Diamond 5",
+  "Diamond 4",
+  "Diamond 3",
+  "Diamond 2",
+  "Diamond 1",
+  "Ruby 5",
+  "Ruby 4",
+  "Ruby 3",
+  "Ruby 2",
+  "Ruby 1",
+  "Master 5",
+  "Master 4",
+  "Master 3",
+  "Master 2",
+  "Master 1",
+  "Unrated",
+];
+
+function difficultyToIndex(value) {
+  if (value === undefined || value === null || value === "ALL") return null;
+  const idx = DIFFICULTY_ORDER.indexOf(value);
+  return idx === -1 ? null : idx;
+}
+
+/**
+ * 문제 번호로 검색
+ * @param {number|string} problemNo
+ * @returns {Promise<Array>}
+ */
+export async function searchByNumber(problemNo) {
+  await delay(200);
+  const num = Number(problemNo);
+  if (!num) return [];
+  return MOCK_PROBLEMS.filter((p) => p.id === num);
+}
+
+/**
+ * 복합 조건 검색
+ * @param {{
+ *   difficulty?: string,
+ *   difficultyFrom?: string,
+ *   difficultyTo?: string,
+ *   tag?: string,
+ *   minSolved?: number,
+ *   beforeDate?: string,    // YYYY-MM-DD
+ *   unsolvedOnly?: boolean, // 미해결 문제만 조회할지 여부
+ *   aiRecommend?: boolean   // AI 추천 모드 여부
+ * }} params
+ * @returns {Promise<Array>}
+ */
+export async function searchWithConditions(params = {}) {
+  await delay(200);
+
+  const {
+    difficulty, // 예전 방식: 단일 난이도
+    difficultyFrom, // 새 방식: 난이도 범위 시작
+    difficultyTo, // 새 방식: 난이도 범위 끝
+    tag,
+    minSolved,
+    beforeDate, // 🔹 등록일 필터
+    unsolvedOnly, // 🔹 미해결 필터 (mock에서는 사용 X)
+    aiRecommend, // 🔹 AI 추천 모드 (mock에서는 사용 X)
+  } = params;
+
+  const minDiffRaw = difficultyToIndex(difficultyFrom);
+  const maxDiffRaw = difficultyToIndex(difficultyTo);
+
+  const hasRange = minDiffRaw !== null || maxDiffRaw !== null;
+  const hasSingleDifficulty = !hasRange && difficulty && difficulty !== "ALL";
+
+  //TODO: use for api connection
+  unsolvedOnly;
+  aiRecommend;
+
+  return MOCK_PROBLEMS.filter((p) => {
+    // ===== 난이도 필터 =====
+    if (hasRange) {
+      const pd = difficultyToIndex(p.difficulty);
+      if (pd === null) return false;
+
+      let min = minDiffRaw;
+      let max = maxDiffRaw;
+
+      if (min !== null || max !== null) {
+        if (min === null) min = -Infinity;
+        if (max === null) max = Infinity;
+        if (min > max) {
+          const tmp = min;
+          min = max;
+          max = tmp;
+        }
+        if (pd < min || pd > max) return false;
+      }
+    } else if (hasSingleDifficulty) {
+      if (p.difficulty !== difficulty) return false;
+    }
+
+    // ===== 태그 필터 =====
+    if (
+      tag &&
+      String(tag).trim() &&
+      !p.tags.some((t) => t.toLowerCase().includes(String(tag).toLowerCase()))
+    ) {
+      return false;
+    }
+
+    // ===== 최소 해결자 수 필터 =====
+    if (typeof minSolved === "number" && !Number.isNaN(minSolved)) {
+      if (p.acceptedUserCount < minSolved) return false;
+    }
+
+    // ===== 날짜 필터 (beforeDate) =====
+    if (beforeDate) {
+      if (!p.registeredAt || p.registeredAt > beforeDate) {
+        return false;
+      }
+    }
+
+    // NOTE:
+    // unsolvedOnly, aiRecommend 는 실제 서버에서
+    //  - unsolvedOnly: 그룹/사용자 기준 미해결 문제만 필터링
+    //  - aiRecommend: AI 추천 알고리즘을 적용한 문제 목록 반환
+    // 에 사용된다고 가정하고, mock 에서는 별도 로직을 넣지 않습니다.
+
+    return true;
+  });
+}
+
+/**
+ * 게시 요청 (제목 + 데드라인 + 문제 목록)
+ * @param {{ title: string, deadline: string|null, problems: Array }} payload
+ * @returns {Promise<{success: boolean, received: any}>}
+ */
+export async function postBoard(payload) {
+  await delay(300);
+  console.log("mock postBoard payload:", payload);
+  return {
+    success: true,
+    received: payload,
+  };
+}

--- a/src/services/problemService.js
+++ b/src/services/problemService.js
@@ -1,0 +1,32 @@
+import { apiMode } from "@/config/apiMode";
+import * as problemApi from "@/api/problemApi";
+import {
+  searchByNumber as mockSearchByNumber,
+  searchWithConditions as mockSearchWithConditions,
+  postBoard as mockPostBoard,
+} from "@/mocks/problem.mock";
+
+const USE_MOCK_PROBLEM = apiMode.problem === "mock";
+
+export const problemService = {
+  async searchByNumber(problemNo) {
+    if (USE_MOCK_PROBLEM) {
+      return mockSearchByNumber(problemNo);
+    }
+    return problemApi.searchByNumber(problemNo);
+  },
+
+  async searchWithConditions(params = {}) {
+    if (USE_MOCK_PROBLEM) {
+      return mockSearchWithConditions(params);
+    }
+    return problemApi.searchWithConditions(params);
+  },
+
+  async postBoard(payload) {
+    if (USE_MOCK_PROBLEM) {
+      return mockPostBoard(payload);
+    }
+    return problemApi.postBoard(payload);
+  },
+};

--- a/tests/ProblemBoard.spec.js
+++ b/tests/ProblemBoard.spec.js
@@ -3,7 +3,7 @@ import { mount } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { nextTick } from "vue";
 import ProblemBoard from "../src/components/ProblemBoard.vue";
-import * as api from "../src/api/problemApi";
+import { problemService } from "@/services/problemService";
 
 // 1) vue-router mock
 vi.mock("vue-router", () => ({
@@ -31,7 +31,7 @@ describe("ProblemBoard.vue", () => {
   it("게시 버튼 클릭 시 postBoard 를 올바른 payload 로 호출한다", async () => {
     // postBoard 모킹
     const mockPost = vi
-      .spyOn(api, "postBoard")
+      .spyOn(problemService, "postBoard")
       .mockResolvedValue({ id: 999, success: true });
 
     const wrapper = mount(ProblemBoard, {

--- a/tests/ProblemSearch.spec.js
+++ b/tests/ProblemSearch.spec.js
@@ -1,7 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import ProblemSearch from "../src/components/ProblemSearch.vue";
-import * as api from "../src/api/problemApi";
+import { problemService } from "@/services/problemService";
 
 describe("ProblemSearch.vue", () => {
   beforeEach(() => {
@@ -18,7 +18,9 @@ describe("ProblemSearch.vue", () => {
       acceptedUserCount: 10,
     };
 
-    vi.spyOn(api, "searchWithConditions").mockResolvedValue([problem]);
+    vi.spyOn(problemService, "searchWithConditions").mockResolvedValue([
+      problem,
+    ]);
 
     const wrapper = mount(ProblemSearch);
 


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/27
---
## ✅ 변경 내용

- `src/api/problemApi.js`에 있던 mock 문제 검색/게시 로직을 `src/mocks/problem.mock.js`로 이동했습니다.
- `src/api/problemApi.js`는 real 문제 검색/게시 API를 위한 골격만 남겨두었습니다.
- `src/services/problemService.js`를 추가하여, `apiMode.problem`에 따라 mock/real을 분기하도록 했습니다.
- 기존 컴포넌트/스토어의 문제 검색/게시 호출부를 `problemService`를 통해 호출하도록 리팩토링했습니다.
- 현재는 `apiMode.problem = "mock"` 상태로 동작하며, 기능 동작은 기존과 동일합니다.

## 📂 주요 변경 파일

- `src/mocks/problem.mock.js` (신규, 기존 mock 로직 이동)
- `src/api/problemApi.js` (real API 골격)
- `src/services/problemService.js` (mock/real 분기)
- (문제 검색/게시 관련 컴포넌트/스토어들) import/호출부 변경

## 🔍 리뷰 포인트

- `problemService` 인터페이스가 직관적인지 (`searchByNumber`, `searchWithConditions`, `postBoard`)
- mock/real 분기(`apiMode.problem`) 위치가 적절한지
- 호출부 리팩토링 이후에도 문제 검색/게시 기능이 기존과 동일하게 동작하는지

## 🧪 테스트

- [x] 문제 번호 검색
- [x] 난이도/태그/정답자 수 등 조건 검색
- [x] 선택한 문제들로 보드 게시(postBoard) 기능
