### PR TITLE
[BSM-35] refactor: route all auth/account flows through authService

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,6 +1,29 @@
 import { apiMode } from "@/config/apiMode";
-import { loginWithIdPw, logout as apiLogout } from "@/api/authApi";
-import { mockLogin, mockLogout, mockGetCurrentUser } from "@/mocks/auth.mock";
+import {
+  loginWithIdPw,
+  logout as logoutApi,
+  signupWithIdPw,
+  forgotPassword as forgotPasswordApi,
+  resetPassword as resetPasswordApi,
+  checkUsernameDuplicate as checkUsernameDuplicateApi,
+  verifyBaekjoonId as verifyBaekjoonIdApi,
+  updateBaekjoonId as updateBaekjoonIdApi,
+} from "@/api/authApi";
+import {
+  mockLogin,
+  mockLogout,
+  mockGetCurrentUser,
+  mockSignup,
+  mockForgotPassword,
+  mockResetPassword,
+  mockVerifyPassword,
+  mockUpdateNickname,
+  mockChangePassword,
+  mockDeleteAccount,
+  mockCheckUsernameDuplicate,
+  mockCheckBaekjoonId,
+  mockUpdateBaekjoonId,
+} from "@/mocks/auth.mock";
 
 const USE_MOCK_AUTH = apiMode.auth === "mock";
 
@@ -37,7 +60,9 @@ export const authService = {
     // TODO: 백엔드에서 /members/me 준비되면 아래 구현
     // const me = await getMyProfile();
     // return me;
-    return null;
+    throw new Error(
+      "authService.fetchCurrentUser: not implemented for real API yet",
+    );
   },
 
   /**
@@ -49,6 +74,135 @@ export const authService = {
       return;
     }
 
-    await apiLogout();
+    await logoutApi();
+  },
+
+  /**
+   * 회원가입
+   */
+  async signup({ email, nickname, password, baekjoonId }) {
+    if (USE_MOCK_AUTH) {
+      return mockSignup({ email, nickname, password, baekjoonId });
+    }
+
+    const data = await signupWithIdPw({
+      email,
+      nickname,
+      password,
+      baekjoonId,
+    });
+
+    return data;
+  },
+
+  /**
+   * 비밀번호 재설정 메일 발송
+   */
+  async forgotPassword({ email }) {
+    if (USE_MOCK_AUTH) {
+      return mockForgotPassword({ email });
+    }
+
+    return forgotPasswordApi({ email });
+  },
+
+  /**
+   * 비밀번호 재설정
+   */
+  async resetPassword({ token, newPassword }) {
+    if (USE_MOCK_AUTH) {
+      return mockResetPassword({ token, newPassword });
+    }
+
+    return resetPasswordApi({ token, newPassword });
+  },
+
+  /**
+   * 비밀번호 재확인 (본인 인증)
+   * - mock: 비밀번호 검증 + 최신 user 반환
+   * - real: TODO(/auth/verify-password 준비 시 연동)
+   */
+  async verifyPassword({ password }) {
+    if (USE_MOCK_AUTH) {
+      return mockVerifyPassword({ password });
+    }
+
+    throw new Error(
+      "authService.verifyPassword: not implemented for real API yet",
+    );
+  },
+
+  /**
+   * 비밀번호 변경
+   */
+  async changePassword({ newPassword }) {
+    if (USE_MOCK_AUTH) {
+      return mockChangePassword({ newPassword });
+    }
+
+    throw new Error(
+      "authService.changePassword: not implemented for real API yet",
+    );
+  },
+
+  /**
+   * 닉네임(=username) 중복 확인
+   */
+  async checkUsernameDuplicate({ username }) {
+    if (USE_MOCK_AUTH) {
+      return mockCheckUsernameDuplicate({ username });
+    }
+
+    return checkUsernameDuplicateApi({ username });
+  },
+
+  /**
+   * 백준 아이디 존재 여부 확인
+   */
+  async checkBaekjoonId({ handle }) {
+    if (USE_MOCK_AUTH) {
+      return mockCheckBaekjoonId({ handle });
+    }
+
+    return verifyBaekjoonIdApi({ handle });
+  },
+
+  /**
+   * 닉네임 변경
+   */
+  async updateNickname({ nickname }) {
+    if (USE_MOCK_AUTH) {
+      return mockUpdateNickname({ nickname });
+    }
+
+    // TODO: memberApi.updateMyProfile({ nickname })로 연동
+    throw new Error(
+      "authService.updateNickname: not implemented for real API yet",
+    );
+  },
+
+  /**
+   * 백준 아이디 변경
+   */
+  async updateBaekjoonId({ baekjoonId }) {
+    if (USE_MOCK_AUTH) {
+      return mockUpdateBaekjoonId({ baekjoonId });
+    }
+
+    return updateBaekjoonIdApi({ baekjoonId });
+  },
+
+  /**
+   * 회원 탈퇴
+   */
+  async deleteAccount() {
+    if (USE_MOCK_AUTH) {
+      return mockDeleteAccount();
+    }
+
+    // TODO: memberApi.deleteMyAccount()로 연동
+    throw new Error(
+      "authService.deleteAccount: not implemented for real API yet",
+    );
   },
 };

--- a/src/views/ForgotPasswordView.vue
+++ b/src/views/ForgotPasswordView.vue
@@ -1,12 +1,7 @@
 <script setup>
 import { ref } from "vue";
 import { useRouter } from "vue-router";
-
-// TODO: 나중에 실제 백엔드 붙일 때 쓸 API
-// import { forgotPassword } from "../api/authApi";
-
-// TODO: 지금은 mock 사용 (백엔드 붙기 전까지)
-import { mockForgotPassword } from "@/mocks/auth.mock";
+import { authService } from "@/services/authService";
 
 const router = useRouter();
 
@@ -36,30 +31,7 @@ async function handleSubmit() {
   devResetToken.value = "";
 
   try {
-    /** TODO:
-     * ================================
-     * 1) 지금: mock API 호출
-     * ================================
-     * - localStorage에 저장된 mock 유저 목록에서 토큰 생성
-     * - { ok: true, token } 형태로 응답
-     */
-    const res = await mockForgotPassword({ email: email.value });
-
-    /** TODO:
-     * ================================
-     * 2) 나중: 실제 백엔드 연동
-     * ================================
-     * 백엔드에서 /auth/forgot-password 같은 엔드포인트를 제공한다고 가정.
-     *
-     * const res = await forgotPassword({ email: email.value });
-     *
-     * // 기대 응답:
-     * // { ok: true } 또는 { ok: true, message: "메일 발송 완료" }
-     *
-     * 실제 서비스에서는 토큰을 프론트로 보내지 않고,
-     * 서버에서 바로 이메일을 발송하는 패턴
-     * 이 화면에서는 "메일을 보냈습니다" 정도의 안내
-     */
+    const res = await authService.forgotPassword({ email: email.value });
 
     infoMessage.value =
       "입력하신 이메일로 비밀번호 재설정 안내를 보냈습니다. (이메일이 등록되어 있다면)";

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -2,20 +2,7 @@
 import { ref, watch, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useAuthStore } from "@/data/authStore";
-
-// TODO: 실제 API 전환 시 사용할 예시 (지금은 mock만 사용)
-// import { verifyPassword, changePassword } from "@/api/authApi";
-// import { updateMyProfile, deleteMyAccount, getMyProfile, getMyGroupSummary } from "@/api/memberApi";
-
-import {
-  mockVerifyPassword,
-  mockUpdateNickname,
-  mockChangePassword,
-  mockDeleteAccount,
-  mockCheckUsernameDuplicate,
-  mockCheckBaekjoonId,
-  mockUpdateBaekjoonId,
-} from "@/mocks/auth.mock";
+import { authService } from "@/services/authService";
 
 const router = useRouter();
 const authStore = useAuthStore();
@@ -111,8 +98,7 @@ async function handleVerifyPassword() {
 
   verifyLoading.value = true;
   try {
-    // TODO: 지금은 mock 사용
-    const res = await mockVerifyPassword({ password: pwd });
+    const res = await authService.verifyPassword({ password: pwd });
 
     const user = res.user;
     email.value = user.email;
@@ -159,8 +145,7 @@ async function handleCheckNickname() {
   isCheckingNickname.value = true;
 
   try {
-    // TODO: 실제 API 전환 시 checkUsernameDuplicate 사용
-    const res = await mockCheckUsernameDuplicate({ username: value });
+    const res = await authService.checkUsernameDuplicate({ username: value });
 
     const duplicated =
       res.duplicated ??
@@ -232,8 +217,7 @@ async function handleSaveNickname() {
   isSavingNickname.value = true;
 
   try {
-    // TODO: 지금은 mock 사용
-    const res = await mockUpdateNickname({ nickname: value });
+    const res = await authService.updateNickname({ nickname: value });
     const user = res.user;
 
     nickname.value = user.nickname;
@@ -276,8 +260,7 @@ async function handleCheckBaekjoonId() {
   isCheckingBaekjoonId.value = true;
 
   try {
-    // TODO: 실제 백엔드로 교체 예정
-    const res = await mockCheckBaekjoonId({ handle });
+    const res = await authService.checkBaekjoonId({ handle });
     if (res.exists) {
       isBaekjoonValid.value = true;
       baekjoonCheckMessage.value = "존재하는 백준 아이디입니다.";
@@ -339,8 +322,7 @@ async function handleSaveBaekjoonId() {
   isSavingBaekjoonId.value = true;
 
   try {
-    // TODO: 실제 서버 API로 전환 예정
-    const res = await mockUpdateBaekjoonId({ baekjoonId: value });
+    const res = await authService.updateBaekjoonId({ baekjoonId: value });
     const user = res.user;
 
     baekjoonId.value = user.baekjoonId || "";
@@ -386,8 +368,7 @@ async function handleChangePassword() {
   isChangingPassword.value = true;
 
   try {
-    // TODO: 지금은 mock 사용
-    await mockChangePassword({ newPassword: pwd });
+    await authService.changePassword({ newPassword: pwd });
 
     // 보안상 비밀번호 변경 후 세션 끊고 재로그인 요구
     await authStore.logout();
@@ -436,9 +417,7 @@ async function handleDeleteAccount() {
      *
      * await deleteMyAccount();
      */
-
-    // 지금은 mock에서는 그룹 개념이 없으니 바로 탈퇴
-    await mockDeleteAccount();
+    await authService.deleteAccount();
 
     // 세션/스토어 정리
     await authStore.logout();

--- a/src/views/ResetPasswordView.vue
+++ b/src/views/ResetPasswordView.vue
@@ -1,12 +1,7 @@
 <script setup>
 import { ref, computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
-
-// TODO: 나중에 실제 백엔드 붙일 때 쓸 API
-// import { resetPassword } from "../api/authApi";
-
-// TODO: 지금은 mock 사용
-import { mockResetPassword } from "@/mocks/auth.mock";
+import { authService } from "@/services/authService";
 
 const route = useRoute();
 const router = useRouter();
@@ -53,36 +48,10 @@ async function handleSubmit() {
   successMessage.value = "";
 
   try {
-    /**
-     * TODO: ================================
-     * 1) 지금: mock API 호출
-     * ================================
-     * localStorage에 저장된 resetTokens에서 토큰 검증 후
-     * 해당 유저의 password를 교체하는 방식.
-     */
-    await mockResetPassword({
+    await authService.resetPassword({
       token: token.value,
       newPassword: password.value,
     });
-
-    /** TODO:
-     * ================================
-     * 2) 나중: 실제 백엔드 연동
-     * ================================
-     * 백엔드에서 /auth/reset-password 같은 엔드포인트를 제공한다고 가정.
-     *
-     * await resetPassword({
-     *   token: token.value,
-     *   newPassword: password.value,
-     * });
-     *
-     * // 기대 응답:
-     * // { ok: true } 또는 { ok: true, message: "비밀번호 변경 완료" }
-     *
-     * 서버에서는 토큰 유효성/만료 여부를 확인하고,
-     * 비밀번호를 해싱(BCrypt/Argon2 등)해서 저장한 뒤
-     * 기존 세션/토큰을 모두 무효화해야 함.
-     */
 
     successMessage.value =
       "비밀번호가 변경되었습니다. 새 비밀번호로 다시 로그인해 주세요.";

--- a/src/views/SignupView.vue
+++ b/src/views/SignupView.vue
@@ -1,16 +1,7 @@
 <script setup>
 import { ref, watch, computed } from "vue";
 import { useRouter } from "vue-router";
-
-// TODO: 실제 회원가입 API (ID/PW 기반)
-// import { signupWithIdPw, checkUsernameDuplicate, verifyBaekjoonId } from "@/api/authApi";
-
-// TODO: TODO: mock 버전
-import {
-  mockSignup,
-  mockCheckUsernameDuplicate,
-  mockCheckBaekjoonId,
-} from "@/mocks/auth.mock";
+import { authService } from "@/services/authService";
 
 const router = useRouter();
 
@@ -73,8 +64,7 @@ async function handleCheckNickname() {
   isCheckingNickname.value = true;
 
   try {
-    //TODO: change this code to actually api code
-    const res = await mockCheckUsernameDuplicate({ username: value });
+    const res = await authService.checkUsernameDuplicate({ username: value });
 
     const duplicated =
       res.duplicated ??
@@ -88,10 +78,6 @@ async function handleCheckNickname() {
       isNicknameDuplicated.value = false;
       nicknameCheckMessage.value = "사용 가능한 닉네임입니다.";
     }
-
-    //TODO: change upper code to this code for actual API
-    // const res = await checkUsernameDuplicate({ username: value });
-    // const duplicated = res.duplicated; // 응답 형식에 맞게 수정
   } catch (e) {
     isNicknameDuplicated.value = null;
     nicknameCheckMessage.value =
@@ -115,8 +101,7 @@ async function handleCheckBaekjoonId() {
   isCheckingBaekjoon.value = true;
 
   try {
-    // TODO: 지금은 mock, 나중에 서버 API로 교체
-    const res = await mockCheckBaekjoonId({ handle });
+    const res = await authService.checkBaekjoonId({ handle });
     // 가정: { exists: boolean }
     if (res.exists) {
       isBaekjoonValid.value = true;
@@ -126,10 +111,6 @@ async function handleCheckBaekjoonId() {
       baekjoonCheckMessage.value =
         "존재하지 않는 백준 아이디입니다. 다시 확인해주세요.";
     }
-
-    // TODO: 실제 API 예시
-    // const res = await verifyBaekjoonId({ handle });
-    // isBaekjoonValid.value = res.exists;
   } catch (e) {
     console.error(e);
     isBaekjoonValid.value = null;
@@ -182,21 +163,12 @@ async function handleSubmit() {
 
   isSubmitting.value = true;
   try {
-    // TODO: 1) 지금: mock + ID/PW
-    await mockSignup({
+    await authService.signup({
       email: email.value,
       nickname: nickname.value,
       password: password.value,
       baekjoonId: baekjoonId.value,
     });
-
-    // TODO: 2) 나중: 실제 API
-    // await signupWithIdPw({
-    //   email: email.value,
-    //   nickname: nickname.value,
-    //   password: password.value,
-    //   baekjoonId: baekjoonId.value,
-    // });
 
     router.push({ name: "Login" });
   } catch (e) {

--- a/tests/ForgotPasswordView.spec.js
+++ b/tests/ForgotPasswordView.spec.js
@@ -9,7 +9,13 @@ vi.mock("vue-router", () => ({
   }),
 }));
 
-import * as mockAuthApi from "@/mocks/auth.mock";
+vi.mock("@/services/authService", () => ({
+  authService: {
+    forgotPassword: vi.fn(),
+  },
+}));
+
+import { authService } from "@/services/authService";
 import ForgotPasswordView from "../src/views/ForgotPasswordView.vue";
 
 describe("ForgotPasswordView", () => {
@@ -27,13 +33,11 @@ describe("ForgotPasswordView", () => {
     expect(wrapper.text()).toContain("가입하신 이메일을 입력해주세요.");
   });
 
-  it("유효한 이메일 입력 시 mockForgotPassword를 호출하고 안내 메시지를 보여준다", async () => {
-    const forgotSpy = vi
-      .spyOn(mockAuthApi, "mockForgotPassword")
-      .mockResolvedValue({
-        ok: true,
-        token: "reset-token-123",
-      });
+  it("유효한 이메일 입력 시 authService.forgotPassword를 호출하고 안내 메시지를 보여준다", async () => {
+    authService.forgotPassword.mockResolvedValue({
+      ok: true,
+      token: "reset-token-123",
+    });
 
     const wrapper = mount(ForgotPasswordView);
 
@@ -41,7 +45,7 @@ describe("ForgotPasswordView", () => {
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
-    expect(forgotSpy).toHaveBeenCalledWith({
+    expect(authService.forgotPassword).toHaveBeenCalledWith({
       email: "user@example.com",
     });
 
@@ -54,7 +58,7 @@ describe("ForgotPasswordView", () => {
   });
 
   it("개발용 버튼 클릭 시 ResetPassword 라우트로 이동한다", async () => {
-    vi.spyOn(mockAuthApi, "mockForgotPassword").mockResolvedValue({
+    authService.forgotPassword.mockResolvedValue({
       ok: true,
       token: "reset-token-456",
     });

--- a/tests/MyPageView.spec.js
+++ b/tests/MyPageView.spec.js
@@ -36,9 +36,21 @@ vi.mock("@/data/authStore", () => {
 });
 
 // =======================
-// 2) mockAuthApi 실제 모듈 import 후 spy
+// 2) authService mock
 // =======================
-import * as mockAuthApi from "@/mocks/auth.mock";
+vi.mock("@/services/authService", () => ({
+  authService: {
+    verifyPassword: vi.fn(),
+    checkUsernameDuplicate: vi.fn(),
+    updateNickname: vi.fn(),
+    checkBaekjoonId: vi.fn(),
+    updateBaekjoonId: vi.fn(),
+    changePassword: vi.fn(),
+    deleteAccount: vi.fn(),
+  },
+}));
+
+import { authService } from "@/services/authService";
 import MyPageView from "@/views/MyPageView.vue";
 
 // 프로필 단계로 강제 진입시키는 헬퍼
@@ -92,9 +104,8 @@ describe("MyPageView.vue", () => {
   });
 
   it("비밀번호 재확인에서 8자 미만이면 에러를 보여주고 API를 호출하지 않는다", async () => {
-    const verifySpy = vi
-      .spyOn(mockAuthApi, "mockVerifyPassword")
-      .mockResolvedValue({});
+    const verifySpy = authService.verifyPassword;
+    verifySpy.mockResolvedValue({});
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -112,16 +123,15 @@ describe("MyPageView.vue", () => {
     expect(verifySpy).not.toHaveBeenCalled();
   });
 
-  it("올바른 비밀번호 입력 시 mockVerifyPassword 호출 후 프로필 단계로 전환되고, 이메일/닉네임/백준 아이디가 세팅된다", async () => {
-    const verifySpy = vi
-      .spyOn(mockAuthApi, "mockVerifyPassword")
-      .mockResolvedValue({
-        user: {
-          email: "me@example.com",
-          nickname: "myNick",
-          baekjoonId: "tourist",
-        },
-      });
+  it("올바른 비밀번호 입력 시 authService.verifyPassword 호출 후 프로필 단계로 전환되고, 이메일/닉네임/백준 아이디가 세팅된다", async () => {
+    const verifySpy = authService.verifyPassword;
+    verifySpy.mockResolvedValue({
+      user: {
+        email: "me@example.com",
+        nickname: "myNick",
+        baekjoonId: "tourist",
+      },
+    });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -149,9 +159,8 @@ describe("MyPageView.vue", () => {
   });
 
   it("비밀번호가 틀리면 에러 메시지를 보여준다", async () => {
-    const verifySpy = vi
-      .spyOn(mockAuthApi, "mockVerifyPassword")
-      .mockRejectedValue({ code: "INVALID_PASSWORD" });
+    const verifySpy = authService.verifyPassword;
+    verifySpy.mockRejectedValue({ code: "INVALID_PASSWORD" });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -169,12 +178,11 @@ describe("MyPageView.vue", () => {
   });
 
   it("닉네임 중복 확인에서 사용 가능한 닉네임이면 메시지를 표시한다", async () => {
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckUsernameDuplicate")
-      .mockResolvedValue({
-        duplicated: false,
-        available: true,
-      });
+    const checkSpy = authService.checkUsernameDuplicate;
+    checkSpy.mockResolvedValue({
+      duplicated: false,
+      available: true,
+    });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -200,15 +208,14 @@ describe("MyPageView.vue", () => {
     expect(wrapper.text()).toContain("사용 가능한 닉네임입니다.");
   });
 
-  it("닉네임 중복 확인 없이 저장 시 에러를 보여주고 mockUpdateNickname을 호출하지 않는다", async () => {
-    const updateSpy = vi
-      .spyOn(mockAuthApi, "mockUpdateNickname")
-      .mockResolvedValue({
-        user: {
-          email: "user@example.com",
-          nickname: "newNick",
-        },
-      });
+  it("닉네임 중복 확인 없이 저장 시 에러를 보여주고 authService.updateNickname을 호출하지 않는다", async () => {
+    const updateSpy = authService.updateNickname;
+    updateSpy.mockResolvedValue({
+      user: {
+        email: "user@example.com",
+        nickname: "newNick",
+      },
+    });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -231,24 +238,22 @@ describe("MyPageView.vue", () => {
     expect(updateSpy).not.toHaveBeenCalled();
   });
 
-  it("닉네임 중복 확인 후 저장 시 mockUpdateNickname과 fetchCurrentUser를 호출한다", async () => {
+  it("닉네임 중복 확인 후 저장 시 authService.checkUsernameDuplicate과 authService.updateNickname를 호출한다", async () => {
     const g = globalThis.__authMocks;
 
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckUsernameDuplicate")
-      .mockResolvedValue({
-        duplicated: false,
-        available: true,
-      });
+    const checkSpy = authService.checkUsernameDuplicate;
+    checkSpy.mockResolvedValue({
+      duplicated: false,
+      available: true,
+    });
 
-    const updateSpy = vi
-      .spyOn(mockAuthApi, "mockUpdateNickname")
-      .mockResolvedValue({
-        user: {
-          email: "user@example.com",
-          nickname: "newNick",
-        },
-      });
+    const updateSpy = authService.updateNickname;
+    updateSpy.mockResolvedValue({
+      user: {
+        email: "user@example.com",
+        nickname: "newNick",
+      },
+    });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -283,10 +288,9 @@ describe("MyPageView.vue", () => {
   // 백준 아이디 관련 테스트
   // ============================
 
-  it("백준 아이디 입력이 없으면 '아이디 확인' 버튼이 비활성화되고 mockCheckBaekjoonId를 호출하지 않는다", async () => {
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
-      .mockResolvedValue({ exists: true });
+  it("백준 아이디 입력이 없으면 '아이디 확인' 버튼이 비활성화되고 authService.checkBaekjoonId를 호출하지 않는다", async () => {
+    const checkSpy = authService.checkBaekjoonId;
+    checkSpy.mockResolvedValue({ exists: true });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -320,9 +324,8 @@ describe("MyPageView.vue", () => {
   });
 
   it("현재 등록된 백준 아이디와 동일한 값을 확인하면 API 호출 없이 유효 처리한다", async () => {
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
-      .mockResolvedValue({ exists: true });
+    const checkSpy = authService.checkBaekjoonId;
+    checkSpy.mockResolvedValue({ exists: true });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -348,9 +351,8 @@ describe("MyPageView.vue", () => {
   });
 
   it("존재하는 백준 아이디라면 아이디 확인 시 성공 메시지를 보여준다", async () => {
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
-      .mockResolvedValue({ exists: true });
+    const checkSpy = authService.checkBaekjoonId;
+    checkSpy.mockResolvedValue({ exists: true });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -377,16 +379,15 @@ describe("MyPageView.vue", () => {
     expect(wrapper.text()).toContain("존재하는 백준 아이디입니다.");
   });
 
-  it("백준 아이디 확인 없이 저장 시 에러를 보여주고 mockUpdateBaekjoonId를 호출하지 않는다", async () => {
-    const updateSpy = vi
-      .spyOn(mockAuthApi, "mockUpdateBaekjoonId")
-      .mockResolvedValue({
-        user: {
-          email: "user@example.com",
-          nickname: "oldNick",
-          baekjoonId: "tourist",
-        },
-      });
+  it("백준 아이디 확인 없이 저장 시 에러를 보여주고 authService.updateBaekjoonId를 호출하지 않는다", async () => {
+    const updateSpy = authService.updateBaekjoonId;
+    updateSpy.mockResolvedValue({
+      user: {
+        email: "user@example.com",
+        nickname: "oldNick",
+        baekjoonId: "tourist",
+      },
+    });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -415,22 +416,20 @@ describe("MyPageView.vue", () => {
     expect(updateSpy).not.toHaveBeenCalled();
   });
 
-  it("백준 아이디 확인 후 저장 시 mockUpdateBaekjoonId와 fetchCurrentUser를 호출한다", async () => {
+  it("백준 아이디 확인 후 저장 시 authService.checkBaekjoonId와 fetchCurrentUser를 호출한다", async () => {
     const g = globalThis.__authMocks;
 
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
-      .mockResolvedValue({ exists: true });
+    const checkSpy = authService.checkBaekjoonId;
+    checkSpy.mockResolvedValue({ exists: true });
 
-    const updateSpy = vi
-      .spyOn(mockAuthApi, "mockUpdateBaekjoonId")
-      .mockResolvedValue({
-        user: {
-          email: "user@example.com",
-          nickname: "oldNick",
-          baekjoonId: "tourist",
-        },
-      });
+    const updateSpy = authService.updateBaekjoonId;
+    updateSpy.mockResolvedValue({
+      user: {
+        email: "user@example.com",
+        nickname: "oldNick",
+        baekjoonId: "tourist",
+      },
+    });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -465,16 +464,15 @@ describe("MyPageView.vue", () => {
     expect(wrapper.text()).toContain("백준 아이디가 변경되었습니다.");
   });
 
-  it("백준 아이디를 빈 문자열로 저장하려 하면 에러를 보여주고 mockUpdateBaekjoonId를 호출하지 않는다", async () => {
-    const updateSpy = vi
-      .spyOn(mockAuthApi, "mockUpdateBaekjoonId")
-      .mockResolvedValue({
-        user: {
-          email: "user@example.com",
-          nickname: "oldNick",
-          baekjoonId: "",
-        },
-      });
+  it("백준 아이디를 빈 문자열로 저장하려 하면 에러를 보여주고 authService.updateBaekjoonId를 호출하지 않는다", async () => {
+    const updateSpy = authService.updateBaekjoonId;
+    updateSpy.mockResolvedValue({
+      user: {
+        email: "user@example.com",
+        nickname: "oldNick",
+        baekjoonId: "",
+      },
+    });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -504,10 +502,9 @@ describe("MyPageView.vue", () => {
   // 비밀번호 / 탈퇴 기존 테스트
   // ============================
 
-  it("비밀번호 변경에서 8자 미만이면 에러를 보여주고 mockChangePassword를 호출하지 않는다", async () => {
-    const changeSpy = vi
-      .spyOn(mockAuthApi, "mockChangePassword")
-      .mockResolvedValue({});
+  it("비밀번호 변경에서 8자 미만이면 에러를 보여주고 authService.changePassword를 호출하지 않는다", async () => {
+    const changeSpy = authService.changePassword;
+    changeSpy.mockResolvedValue({});
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -533,12 +530,11 @@ describe("MyPageView.vue", () => {
     expect(changeSpy).not.toHaveBeenCalled();
   });
 
-  it("비밀번호 변경 성공 시 mockChangePassword와 logout을 호출하고 Login으로 이동한다", async () => {
+  it("비밀번호 변경 성공 시 authService.changePassword와 logout을 호출하고 Login으로 이동한다", async () => {
     const g = globalThis.__authMocks;
 
-    const changeSpy = vi
-      .spyOn(mockAuthApi, "mockChangePassword")
-      .mockResolvedValue({});
+    const changeSpy = authService.changePassword;
+    changeSpy.mockResolvedValue({});
 
     const wrapper = mount(MyPageView);
     await flushPromises();
@@ -571,12 +567,11 @@ describe("MyPageView.vue", () => {
     });
   });
 
-  it("회원 탈퇴 확인 후 mockDeleteAccount와 logout을 호출하고 Home으로 이동한다", async () => {
+  it("회원 탈퇴 확인 후 authService.deleteAccount와 logout을 호출하고 Home으로 이동한다", async () => {
     const g = globalThis.__authMocks;
 
-    const deleteSpy = vi
-      .spyOn(mockAuthApi, "mockDeleteAccount")
-      .mockResolvedValue({});
+    const deleteSpy = authService.deleteAccount;
+    deleteSpy.mockResolvedValue({});
 
     const wrapper = mount(MyPageView);
     await flushPromises();

--- a/tests/ResetPasswordView.spec.js
+++ b/tests/ResetPasswordView.spec.js
@@ -15,7 +15,13 @@ vi.mock("vue-router", () => ({
   }),
 }));
 
-import * as mockAuthApi from "@/mocks/auth.mock";
+vi.mock("@/services/authService", () => ({
+  authService: {
+    resetPassword: vi.fn(),
+  },
+}));
+
+import { authService } from "@/services/authService";
 import ResetPasswordView from "../src/views/ResetPasswordView.vue";
 
 describe("ResetPasswordView", () => {
@@ -48,10 +54,8 @@ describe("ResetPasswordView", () => {
     );
   });
 
-  it("유효한 입력 시 mockResetPassword를 호출하고 성공 메시지를 보여준다", async () => {
-    const resetSpy = vi
-      .spyOn(mockAuthApi, "mockResetPassword")
-      .mockResolvedValue({ ok: true });
+  it("유효한 입력 시 authService.resetPassword를 호출하고 성공 메시지를 보여준다", async () => {
+    authService.resetPassword.mockResolvedValue({ ok: true });
 
     const wrapper = mount(ResetPasswordView);
 
@@ -60,7 +64,7 @@ describe("ResetPasswordView", () => {
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
-    expect(resetSpy).toHaveBeenCalledWith({
+    expect(authService.resetPassword).toHaveBeenCalledWith({
       token: "reset-token-123",
       newPassword: "password123",
     });
@@ -71,7 +75,7 @@ describe("ResetPasswordView", () => {
   });
 
   it("mockResetPassword에서 INVALID_OR_EXPIRED_TOKEN 에러가 나면 해당 메시지를 보여준다", async () => {
-    vi.spyOn(mockAuthApi, "mockResetPassword").mockRejectedValue(
+    authService.resetPassword.mockRejectedValue(
       Object.assign(new Error("유효하지 않거나 만료된 링크입니다."), {
         code: "INVALID_OR_EXPIRED_TOKEN",
       }),

--- a/tests/SignupView.spec.js
+++ b/tests/SignupView.spec.js
@@ -9,7 +9,15 @@ vi.mock("vue-router", () => ({
   }),
 }));
 
-import * as mockAuthApi from "@/mocks/auth.mock";
+vi.mock("@/services/authService", () => ({
+  authService: {
+    signup: vi.fn(),
+    checkBaekjoonId: vi.fn(),
+    checkUsernameDuplicate: vi.fn(),
+  },
+}));
+
+import { authService } from "@/services/authService";
 import SignupView from "@/views/SignupView.vue";
 
 async function goToFormStep(wrapper) {
@@ -62,7 +70,8 @@ describe("SignupView", () => {
   });
 
   it("백준 아이디 확인을 하지 않으면 에러를 보여주고 mockSignup을 호출하지 않는다", async () => {
-    const signupSpy = vi.spyOn(mockAuthApi, "mockSignup").mockResolvedValue({
+    const signupSpy = authService.signup;
+    signupSpy.mockResolvedValue({
       user: {
         id: 1,
         email: "user@example.com",
@@ -92,7 +101,7 @@ describe("SignupView", () => {
   });
 
   it("비밀번호와 확인이 다르면 에러를 보여준다", async () => {
-    vi.spyOn(mockAuthApi, "mockCheckBaekjoonId").mockResolvedValue({
+    authService.checkBaekjoonId.mockResolvedValue({
       exists: true,
     });
 
@@ -123,7 +132,8 @@ describe("SignupView", () => {
   });
 
   it("유효한 입력 시 mockSignup 호출 후 Login으로 이동한다", async () => {
-    const signupSpy = vi.spyOn(mockAuthApi, "mockSignup").mockResolvedValue({
+    const signupSpy = authService.signup;
+    signupSpy.mockResolvedValue({
       user: {
         id: 1,
         email: "user@example.com",
@@ -132,11 +142,10 @@ describe("SignupView", () => {
       },
     });
 
-    const baekjoonSpy = vi
-      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
-      .mockResolvedValue({
-        exists: true,
-      });
+    const baekjoonSpy = authService.checkBaekjoonId;
+    baekjoonSpy.mockResolvedValue({
+      exists: true,
+    });
 
     const wrapper = mount(SignupView);
     await goToFormStep(wrapper);
@@ -170,11 +179,10 @@ describe("SignupView", () => {
   });
 
   it("백준 아이디 확인 버튼 클릭 시 mockCheckBaekjoonId를 호출하고 존재하는 아이디면 성공 메시지를 보여준다", async () => {
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
-      .mockResolvedValue({
-        exists: true,
-      });
+    const checkSpy = authService.checkBaekjoonId;
+    checkSpy.mockResolvedValue({
+      exists: true,
+    });
 
     const wrapper = mount(SignupView);
     await goToFormStep(wrapper);
@@ -194,11 +202,10 @@ describe("SignupView", () => {
   });
 
   it("백준 아이디 확인 시 존재하지 않는 아이디면 경고 메시지를 보여준다", async () => {
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckBaekjoonId")
-      .mockResolvedValue({
-        exists: false,
-      });
+    const checkSpy = authService.checkBaekjoonId;
+    checkSpy.mockResolvedValue({
+      exists: false,
+    });
 
     const wrapper = mount(SignupView);
     await goToFormStep(wrapper);
@@ -220,12 +227,11 @@ describe("SignupView", () => {
   });
 
   it("닉네임 중복 확인 버튼 클릭 시 mockCheckUsernameDuplicate를 호출하고 사용 가능 메시지를 보여준다", async () => {
-    const checkSpy = vi
-      .spyOn(mockAuthApi, "mockCheckUsernameDuplicate")
-      .mockResolvedValue({
-        duplicated: false,
-        available: true,
-      });
+    const checkSpy = authService.checkUsernameDuplicate;
+    checkSpy.mockResolvedValue({
+      duplicated: false,
+      available: true,
+    });
 
     const wrapper = mount(SignupView);
     await goToFormStep(wrapper);
@@ -246,12 +252,13 @@ describe("SignupView", () => {
   });
 
   it("중복된 닉네임이면 경고 메시지를 보여주고, 제출 시 mockSignup이 호출되지 않는다", async () => {
-    vi.spyOn(mockAuthApi, "mockCheckUsernameDuplicate").mockResolvedValue({
+    authService.checkUsernameDuplicate.mockResolvedValue({
       duplicated: true,
       available: false,
     });
 
-    const signupSpy = vi.spyOn(mockAuthApi, "mockSignup").mockResolvedValue({
+    const signupSpy = authService.signup;
+    signupSpy.mockResolvedValue({
       user: {
         id: 1,
         email: "dup@example.com",


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/35
---
## ✅ 이 PR에서 구현한 내용

### 1. authService에 auth/account 관련 메서드 일원화

auth 도메인에서 View가 직접 `@/mocks/auth.mock`를 참조하던 부분을 모두
`authService`를 통해 우회하도록 정리했습니다.

### 2. View 레벨에서 mock 직접 참조 제거

다음 View들은 이제 `authService`만 바라보도록 수정했습니다.
mock 모드에서는 기존 mock 함수의 응답 shape를 그대로 유지하여
UI 로직 변경 없이 동작하도록 했습니다.

### 3. real 모드 대비 TODO 정리

- 아직 백엔드 엔드포인트가 없는 기능들(verifyPassword, changePassword, updateNickname, deleteAccount)에 대해
  - real 모드 분기에서 명시적으로 Error를 던지고,
  - 각 메서드에 TODO 주석으로 예상 엔드포인트/연결 위치를 남겼습니다.

---

## 📂 주요 변경 파일

- `src/services/authService.js`
  - auth/account 관련 메서드 추가 및 mock/real 분기 처리

- `src/views/SignupView.vue`
- `src/views/ForgotPasswordView.vue`
- `src/views/ResetPasswordView.vue`
- `src/views/MyPageView.vue`
  - `@/mocks/auth.mock` import 제거
  - `authService` 호출로 변경

---

## 🧪 테스트 방법

> 현재 `apiMode.auth === "mock"` 기준으로 수동 테스트했습니다.

1. 회원가입
   - 회원가입 화면에서 닉네임/백준 아이디 중복/존재 여부 확인 후 회원가입
2. 로그인 후 마이페이지
   - 비밀번호 재인증 → 이메일/닉네임/백준 아이디 로드 확인
3. 닉네임 변경
   - 새 닉네임 입력 → 중복 확인 → 저장
   - 헤더/전역 상태의 닉네임 동기화 확인
4. 백준 아이디 변경
   - 새 아이디 입력 → 존재 여부 확인 → 저장
5. 비밀번호 변경
   - 비밀번호 변경 후 자동 로그아웃 및 Login 페이지 redirect 확인
6. 비밀번호 찾기/재설정
   - ForgotPassword에서 메일 발송 요청 (mock: dev 토큰 노출)
   - ResetPassword에서 토큰 + 새 비밀번호로 변경
7. 회원 탈퇴
   - “탈퇴합니다” 입력 후 탈퇴 → 세션 정리 및 홈으로 이동 확인