### PR TITLE
[BSM-38] feat: switch login/logout to real auth api

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,5 +1,3 @@
-// import httpClient from "./httpClient";
-// JWT 도입 시 아래처럼 교체:
 import httpClient, { setAccessToken, clearAccessToken } from "./httpClient";
 
 /**

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,19 +1,57 @@
-import httpClient from "./httpClient";
+// import httpClient from "./httpClient";
 // JWT 도입 시 아래처럼 교체:
-// import httpClient, { setAccessToken, clearAccessToken } from "./httpClient";
+import httpClient, { setAccessToken, clearAccessToken } from "./httpClient";
 
 /**
- * 1) 지금 당장 쓸 버전 (ID/PW + 세션)
- *    - 서버가 세션 쿠키를 내려주거나, { user } 형태 응답을 내려준다고 가정
+ * 로그인 (이메일 + 비밀번호)
+ *
+ * POST /api/v1/auth/login
+ *
+ * LoginRequest:
+ *  {
+ *    email: string,
+ *    password: string
+ *  }
+ *
+ * LoginResponse:
+ *  {
+ *    userId: number,
+ *    email: string,
+ *    username: string,
+ *    token: string,        // access token (JWT)
+ *    refreshToken: string, // refresh token (추후 사용)
+ *  }
  */
-export async function loginWithIdPw({ id, password }) {
+export async function loginWithIdPw({ email, password }) {
   const response = await httpClient.post("/auth/login", {
-    id, // 이메일을 ID로 쓰면 프론트에서 email을 그대로 넣으면 됨
+    email,
     password,
   });
 
-  // 예시: { user: { id, nickname, ... } }
-  return response.data;
+  const {
+    userId,
+    email: resEmail,
+    username,
+    token,
+    refreshToken,
+  } = response.data;
+
+  // accessToken을 httpClient 인터셉터에 등록해서
+  // 이후 요청에 Authorization 헤더가 자동으로 붙도록 함
+  if (token) {
+    setAccessToken(token);
+  }
+
+  return {
+    user: {
+      id: userId,
+      email: resEmail,
+      // FE에서 기존에 nickname을 쓰고 있으니 username을 nickname으로 매핑
+      nickname: username,
+    },
+    accessToken: token,
+    refreshToken,
+  };
 }
 
 /**
@@ -76,10 +114,12 @@ export async function updateBaekjoonId({ baekjoonId }) {
  * 로그아웃 (세션 기반)
  */
 export async function logout() {
-  const response = await httpClient.post("/auth/logout");
-  return response.data;
+  try {
+    await httpClient.post("/auth/logout");
+  } finally {
+    clearAccessToken();
+  }
 }
-
 /**
  * 비밀번호 재설정 메일 발송
  */

--- a/src/data/authStore.js
+++ b/src/data/authStore.js
@@ -19,7 +19,7 @@ function clearUser() {
 
 /**
  * 로그인
- * @param {{ id: string, password: string }} credentials
+ * @param {{ email: string, password: string }} credentials
  */
 async function login(credentials) {
   state.isLoading = true;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -43,8 +43,8 @@ export const authService = {
     }
 
     // real: 백엔드 /auth/login
-    const data = await loginWithIdPw({ id, password });
-    return data.user ?? data;
+    const { user } = await loginWithIdPw({ email: id, password });
+    return user;
   },
 
   /**

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -30,20 +30,20 @@ const USE_MOCK_AUTH = apiMode.auth === "mock";
 export const authService = {
   /**
    * 로그인
-   * @param {{ id: string, password: string }} credentials
+   * @param {{ email: string, password: string }} credentials
    */
-  async login({ id, password }) {
+  async login({ email, password }) {
     if (USE_MOCK_AUTH) {
       // mock: email + password 기반
       const { user: mockUser } = await mockLogin({
-        email: id,
+        email,
         password,
       });
       return mockUser;
     }
 
     // real: 백엔드 /auth/login
-    const { user } = await loginWithIdPw({ email: id, password });
+    const { user } = await loginWithIdPw({ email, password });
     return user;
   },
 

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -41,9 +41,8 @@ async function handleSubmit() {
   auth.resetError();
 
   try {
-    // authStore가 내부에서 mockLogin(or 나중에 loginWithIdPw)을 호출
     await auth.login({
-      id: email.value, // mock에서는 email로 사용
+      email: email.value,
       password: password.value,
     });
 

--- a/tests/LoginView.spec.js
+++ b/tests/LoginView.spec.js
@@ -88,7 +88,7 @@ describe("LoginView", () => {
 
     // LoginView가 authStore.login을 어떻게 부르는지 그대로 검증
     expect(authStore.login).toHaveBeenCalledWith({
-      id: "test@example.com", // LoginView에서 id로 넘기고 있음
+      email: "test@example.com", // LoginView에서 id로 넘기고 있음
       password: "password123",
     });
 


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/38
---
## ✅ 변경 내용

- `authStore`의 로그인/로그아웃 로직을 `src/api/authApi.js` 기반의 실제 인증 API를 사용하도록 전환했습니다.
- `apiMode.auth` 값에 따라 mock(`mockLogin`, `mockLogout`)과 real(`loginWithIdPw`, `logout`)을 스위치하도록 정리했습니다.
- 로그인 실패 시 서버에서 내려주는 에러 메시지가 `state.error`에 반영되도록 에러 처리 로직을 정리했습니다.

## 📂 주요 변경 파일

- `src/api/authApi.js` (login/logout 계약 주석 및 사용 정리)
- `src/data/authStore.js` (mock/real 분기 및 실제 auth API 연동)
- `src/services/authService.js`

## 🔍 리뷰 포인트

- `loginWithIdPw` 호출 시 `id/email` 매핑 등 파라미터가 백엔드 스펙과 정확하게 일치하는지
- mock/real 모드 전환 시 `authStore`의 public 인터페이스(`login`, `logout`, `user`, `error`)가 동일하게 유지되는지
- 에러 메시지 처리 방식이 과도하게 백엔드 내부 에러를 노출하지 않으면서도 사용자에게 충분한 피드백을 주는지

## 🧪 테스트

- [x] `VITE_API_MODE_AUTH=real`에서 로그인/로그아웃 정상 동작
- [x] 잘못된 크리덴셜 입력 시 에러 메시지 노출
- [x] `VITE_API_MODE_AUTH=mock`으로 전환 시 기존과 동일한 mock 로그인 플로우 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication to use email instead of ID for user login.
  * Enhanced token management with automatic registration and cleanup of authentication credentials.
  * Improved logout functionality to reliably clear tokens even if the request fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->