### PR TITLE
[BSM-44] feat: align searchMembers with swagger endpoint + add GroupForm tests

### DIFF
--- a/src/api/memberApi.js
+++ b/src/api/memberApi.js
@@ -2,13 +2,27 @@ import httpClient from "./httpClient";
 
 /**
  * 멤버 검색
+ * /api/v1/users/search
+ *
+ * 반환 형식:
+ * { id, name, nickname, email }
  */
 export async function searchMembers(keyword) {
-  const q = keyword?.trim();
-  const res = await httpClient.get("/v1/members", {
+  const q = String(keyword ?? "").trim();
+  if (!q) return [];
+
+  const res = await httpClient.get("/users/search", {
     params: { query: q },
   });
-  return res.data;
+
+  const list = Array.isArray(res.data) ? res.data : [];
+
+  return list.map((u) => ({
+    id: u.id,
+    name: u.username ?? "",
+    nickname: u.username ?? "",
+    email: u.email ?? "",
+  }));
 }
 
 /**

--- a/tests/GroupForm.spec.js
+++ b/tests/GroupForm.spec.js
@@ -358,4 +358,76 @@ describe("GroupForm.vue", () => {
     const submitButton = findButtonByText(wrapper, "변경 사항 저장");
     expect(submitButton).toBeTruthy();
   });
+
+  it("검색 버튼 클릭 시 searchMembers가 호출된다 (입력값 전달)", async () => {
+    searchMembers.mockResolvedValue([]);
+
+    const wrapper = mount(GroupForm, { props: { mode: "create" } });
+
+    await wrapper
+      .find('input[placeholder="이름 또는 닉네임으로 검색"]')
+      .setValue("이알고");
+
+    const searchButton = findButtonByText(wrapper, "검색");
+    await searchButton.trigger("click");
+    await flushPromises();
+
+    expect(searchMembers).toHaveBeenCalledTimes(1);
+    expect(searchMembers).toHaveBeenCalledWith("이알고");
+  });
+
+  it("검색 input에서 Enter 키를 누르면 searchMembers가 호출된다", async () => {
+    searchMembers.mockResolvedValue([]);
+
+    const wrapper = mount(GroupForm, { props: { mode: "create" } });
+
+    const input = wrapper.find(
+      'input[placeholder="이름 또는 닉네임으로 검색"]',
+    );
+    await input.setValue("알고");
+    await input.trigger("keyup.enter");
+    await flushPromises();
+
+    expect(searchMembers).toHaveBeenCalledTimes(1);
+    expect(searchMembers).toHaveBeenCalledWith("알고");
+  });
+
+  it("검색 중에는 '검색 중...'이 표시되고, 완료되면 사라진다", async () => {
+    let resolve;
+    const pending = new Promise((r) => (resolve = r));
+    searchMembers.mockReturnValue(pending);
+
+    const wrapper = mount(GroupForm, { props: { mode: "create" } });
+
+    await wrapper
+      .find('input[placeholder="이름 또는 닉네임으로 검색"]')
+      .setValue("이알고");
+
+    const searchButton = findButtonByText(wrapper, "검색");
+    await searchButton.trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("검색 중...");
+
+    resolve([]);
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain("검색 중...");
+  });
+
+  it("searchMembers가 실패하면 에러 메시지를 표시한다", async () => {
+    searchMembers.mockRejectedValue(new Error("boom"));
+
+    const wrapper = mount(GroupForm, { props: { mode: "create" } });
+
+    await wrapper
+      .find('input[placeholder="이름 또는 닉네임으로 검색"]')
+      .setValue("이알고");
+
+    const searchButton = findButtonByText(wrapper, "검색");
+    await searchButton.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("멤버 검색 중 오류가 발생했습니다.");
+  });
 });


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/44
---
### ✅ 구현 내용

* **유저 검색 API 스펙 반영**

  * `searchMembers` 호출을 Swagger 기준 `GET /api/v1/users/search?query=` 로 변경
  * 응답 `UserSimpleDto(id, username, email)`을 GroupForm이 쓰는 형태로 매핑해 UI 깨짐 없이 렌더링되도록 처리
* **검색 관련 테스트 추가**

  * `GroupForm`에서 검색 호출/렌더링/선택 동작을 검증하는 테스트 케이스 추가(또는 보강)

---

### 📂 변경 모듈

* `src/api/memberApi.js`

  * `searchMembers(keyword)` → `/users/search` + `params: { query }` 반영

* `GroupForm.spec.js`

  * searchMembers 관련 테스트 케이스 추가/수정

---

### 🧪 시나리오

1. 그룹 생성/수정 폼 진입
2. “이름 또는 닉네임으로 검색” 입력 후 검색 버튼 클릭
3. FE가 `/api/v1/users/search?query=<keyword>`로 요청 전송
4. 검색 결과 리스트에 유저가 렌더링됨
5. 결과 클릭 시 오른쪽 “선택된 멤버”에 추가되고 뱃지가 “선택됨”으로 변경
6. 재클릭/삭제(✕) 시 선택 해제 및 UI 동기화 확인
7. 테스트 실행: `GroupForm.spec.js` 내 검색 관련 케이스 통과

---

### 💡 기타

* 현재 UI는 `name/nickname`을 기대하므로, 백엔드 응답의 `username`을 기준으로 프론트 매핑 정책을 유지했습니다.
* 추후 `nickname`이 별도 필드로 생기면 매핑 로직을 해당 필드로 전환하면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 멤버 검색 입력값 정규화 및 응답 데이터 형식 개선.
  * 검색 오류 처리 및 유효성 검사 강화.

* **테스트**
  * 멤버 검색 기능에 대한 테스트 케이스 추가 (검색 버튼 클릭, 엔터 키 입력, 로딩 상태, 오류 메시지).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->