### PR TITLE
[BSM-41] refactor: migrate board APIs to group-scoped /api/v1 + add boardStatus mode

### DIFF
--- a/src/api/boardApi.js
+++ b/src/api/boardApi.js
@@ -2,52 +2,101 @@ import httpClient from "./httpClient";
 
 /**
  * 그룹 ID에 해당하는 보드 목록 조회
- * GET /v1/groups/{groupId}/boards
+ * GET /api/v1/groups/{groupId}/boards
+ *
+ * query:
+ *  - title?: string
+ *  - writerId?: number
+ *  - from?: string (date-time)
+ *  - to?: string (date-time)
  */
-export async function fetchBoards(groupId) {
-  const res = await httpClient.get(`/v1/groups/${groupId}/boards`);
+export async function fetchBoards(groupId, params = {}) {
+  const res = await httpClient.get(`/groups/${groupId}/boards`, {
+    params,
+  });
   return res.data;
 }
 
 /**
  * 특정 보드 상세 조회
- * GET /v1/boards/{boardId}
+ * GET /api/v1/groups/{groupId}/boards/{boardId}
  */
-export async function fetchBoardById(boardId) {
-  const res = await httpClient.get(`/v1/boards/${boardId}`);
+export async function fetchBoardById(groupId, boardId) {
+  const res = await httpClient.get(`/groups/${groupId}/boards/${boardId}`);
   return res.data;
 }
 
 /**
  * 보드 생성
- * POST /v1/boards
+ * POST /api/v1/groups/{groupId}/boards?requesterId=...
+ *
+ * body: BoardCreateRequest
+ *  - title: string
+ *  - content: string
+ *  - startTime?: string (date-time)
+ *  - endTime?: string (date-time)
+ *  - problemIds: number[]
+ *
+ * 응답: 생성된 boardId (number)
  */
-export async function createBoard(payload) {
-  const res = await httpClient.post("/v1/boards", payload);
-  return res.data;
+export async function createBoard(groupId, requesterId, payload) {
+  const res = await httpClient.post(`/groups/${groupId}/boards`, payload, {
+    params: { requesterId },
+  });
+  return res.data; // boardId (number)
 }
 
 /**
  * 보드 수정
- * PUT /v1/boards/{boardId}
+ * PATCH /api/v1/groups/{groupId}/boards/{boardId}?requesterId=...
+ *
+ * body: BoardUpdateRequest
+ *  - title?: string
+ *  - content?: string
+ *  - startTime?: string (date-time)
+ *  - endTime?: string (date-time)
+ *
+ * 응답: "updated"
  */
-export async function updateBoard(boardId, payload) {
-  const res = await httpClient.put(`/v1/boards/${boardId}`, payload);
+export async function updateBoard(groupId, boardId, requesterId, payload) {
+  const res = await httpClient.patch(
+    `/groups/${groupId}/boards/${boardId}`,
+    payload,
+    {
+      params: { requesterId },
+    },
+  );
   return res.data;
 }
 
 /**
  * 보드 삭제
- * DELETE /v1/boards/{boardId}
+ * DELETE /api/v1/groups/{groupId}/boards/{boardId}?requesterId=...
+ *
+ * 응답: "deleted"
  */
-export async function deleteBoard(boardId) {
-  const res = await httpClient.delete(`/v1/boards/${boardId}`);
+export async function deleteBoard(groupId, boardId, requesterId) {
+  const res = await httpClient.delete(`/groups/${groupId}/boards/${boardId}`, {
+    params: { requesterId },
+  });
   return res.data;
 }
 
 /**
+ * 보드 안에 포함된 문제 목록 (ID 배열)
+ * GET /api/v1/groups/{groupId}/boards/{boardId}/problems
+ */
+export async function getBoardProblems(groupId, boardId) {
+  const res = await httpClient.get(
+    `/groups/${groupId}/boards/${boardId}/problems`,
+  );
+  return res.data; // number[]
+}
+
+// TODO: Swagger
+/**
  * 보드별 유저 풀이 현황
- * GET /v1/groups/{groupId}/boards/{boardId}/userStatus
+ * GET /api/v1/groups/{groupId}/boards/{boardId}/userStatus
  */
 export async function getBoardUserStatus(groupId, boardId) {
   const res = await httpClient.get(

--- a/src/components/BoardList.vue
+++ b/src/components/BoardList.vue
@@ -97,9 +97,19 @@ function goGroupList() {
 }
 
 async function handleDelete(id) {
+  if (!currentUserId.value) {
+    alert("로그인이 필요합니다.");
+    return;
+  }
+
   if (confirm("정말 이 보드를 삭제하시겠습니까?")) {
-    deleteBoard(id);
-    await fetchBoards(route.params.groupId);
+    await deleteBoard({
+      groupId: Number(route.params.groupId),
+      boardId: id,
+      requesterId: currentUserId.value,
+    });
+
+    await fetchBoards(Number(route.params.groupId));
   }
 }
 </script>

--- a/src/components/BoardList.vue
+++ b/src/components/BoardList.vue
@@ -103,13 +103,18 @@ async function handleDelete(id) {
   }
 
   if (confirm("정말 이 보드를 삭제하시겠습니까?")) {
-    await deleteBoard({
-      groupId: Number(route.params.groupId),
-      boardId: id,
-      requesterId: currentUserId.value,
-    });
+    try {
+      await deleteBoard({
+        groupId: Number(route.params.groupId),
+        boardId: id,
+        requesterId: currentUserId.value,
+      });
 
-    await fetchBoards(Number(route.params.groupId));
+      await fetchBoards(Number(route.params.groupId));
+    } catch (e) {
+      console.error(e);
+      alert("보드 삭제 중 오류가 발생했습니다: " + e.message);
+    }
   }
 }
 </script>

--- a/src/components/ProblemBoard.vue
+++ b/src/components/ProblemBoard.vue
@@ -4,16 +4,17 @@ import { useRouter, useRoute } from "vue-router";
 import ProblemSearch from "./ProblemSearch.vue";
 import BoardHeader from "./board/BoardHeader.vue";
 import SelectedProblemsPanel from "./board/SelectedProblemsPanel.vue";
-import { problemService } from "@/services/problemService";
 import {
   addBoard,
   updateBoard,
   fetchBoards,
   fetchBoardById,
 } from "../data/boardStore";
+import { useAuthStore } from "../data/authStore";
 
 const router = useRouter();
 const route = useRoute();
+const authStore = useAuthStore();
 
 const boardId = computed(() => route?.params?.boardId ?? null);
 const isEditMode = computed(() => !!boardId.value);
@@ -28,21 +29,56 @@ const title = ref("");
 const deadline = ref("");
 const selectedProblems = ref([]);
 
+const currentUserId = computed(() => authStore.user.value?.id ?? null);
+
+function normalizeSelectedProblem(p) {
+  if (!p) return null;
+
+  // 구버전/예외: 숫자 id만 오는 경우
+  if (typeof p === "number" || typeof p === "string") {
+    const id = Number(p);
+    return Number.isFinite(id) ? { id } : null;
+  }
+
+  // ✅ 비정상 케이스: p.id가 객체인 경우 (스샷의 [object Object] 원인)
+  if (p.id && typeof p.id === "object") {
+    const inner = p.id;
+    const id = Number(inner.id);
+    if (!Number.isFinite(id)) return null;
+
+    return {
+      id,
+      title: inner.title ?? p.title ?? null,
+      difficulty: inner.difficulty ?? p.difficulty ?? null,
+    };
+  }
+
+  // 정상 케이스
+  const id = Number(p.id);
+  if (!Number.isFinite(id)) return null;
+
+  return {
+    id,
+    title: p.title ?? p.titleKo ?? null,
+    difficulty: p.difficulty ?? null,
+  };
+}
+
 onMounted(async () => {
   if (isEditMode.value) {
     try {
+      const groupId = Number(route.params.groupId);
       // 보드 ID를 이용해 Store에서 기존 데이터를 가져옵니다.
-      const existingBoard = await fetchBoardById(boardId.value);
+      const existingBoard = await fetchBoardById(groupId, boardId.value);
 
       // 폼 필드 초기화
       title.value = existingBoard.title;
       deadline.value = existingBoard.deadline || "";
 
       // 문제 목록 초기화 (문제 상세 데이터 구조가 필요합니다.)
-      // 여기서는 임시로 문제를 로드하는 과정만 표시합니다.
-      selectedProblems.value = existingBoard.problems
-        ? [...existingBoard.problems]
-        : [];
+      selectedProblems.value = (existingBoard.problems || [])
+        .map(normalizeSelectedProblem)
+        .filter(Boolean);
     } catch (e) {
       console.error("보드 데이터 로드 실패:", e);
     }
@@ -56,8 +92,13 @@ const selectedProblemIds = computed(() =>
 
 // 문제 추가 (중복 방지)
 function handleAddProblem(problem) {
-  const exists = selectedProblems.value.some((p) => p.id === problem.id);
-  if (!exists) selectedProblems.value.push(problem);
+  const normalized = normalizeSelectedProblem(problem);
+  if (!normalized) return;
+
+  const exists = selectedProblems.value.some(
+    (p) => Number(p.id) === Number(normalized.id),
+  );
+  if (!exists) selectedProblems.value.push(normalized);
 }
 
 // 문제 제거
@@ -88,7 +129,6 @@ const canPost = computed(
 );
 
 const isPosting = ref(false);
-const postResult = ref(null);
 const postError = ref("");
 
 async function handlePost() {
@@ -100,33 +140,26 @@ async function handlePost() {
 
   if (!canPost.value || isPosting.value) return;
 
+  if (!currentUserId.value) {
+    postError.value = "로그인이 필요합니다.";
+    return;
+  }
+
   isPosting.value = true;
   postError.value = "";
-  postResult.value = null;
 
   try {
-    const payload = {
+    const boardPayload = {
+      groupId: gid,
+      requesterId: currentUserId.value,
       title: title.value.trim(),
       deadline: deadline.value || null,
-      problems: selectedProblems.value.map((p, index) => ({
-        id: p.id,
-        order: index + 1,
-      })),
+      // content 필드는 아직 UI가 없어서 빈 문자열로 처리 (원하면 textarea 추가)
+      content: "",
+      problems: selectedProblems.value.map((p) => ({ ...p })),
     };
 
-    // API 호출 (실제 백엔드는 payload를 저장)
-    const res = await problemService.postBoard(payload);
-    postResult.value = res;
-
-    //TODO: integrate backend
-    addBoard({
-      id: res?.id || Date.now(),
-      groupId: gid,
-      title: payload.title,
-      deadline: payload.deadline,
-      problems: selectedProblems.value,
-      // problemsCount: payload.problems.length,
-    });
+    await addBoard(boardPayload);
 
     await fetchBoards(gid);
 
@@ -153,36 +186,27 @@ async function handleUpdate() {
 
   if (!canPost.value || isPosting.value) return;
 
+  if (!currentUserId.value) {
+    postError.value = "로그인이 필요합니다.";
+    return;
+  }
+
   isPosting.value = true;
   postError.value = "";
 
   try {
-    // 1) 백엔드로 보낼 payload (문제는 id + order만)
-    //    - 실제 백엔드에는 보통 문제 전체 객체를 안 넣고
-    //      { problemId, order } 만 보관한다.
-    const apiPayload = {
-      id: boardId.value,
+    const boardPayload = {
+      id: Number(boardId.value),
       groupId: gid,
+      requesterId: currentUserId.value,
       title: title.value.trim(),
       deadline: deadline.value || null,
-      problems: selectedProblems.value.map((p, index) => ({
-        id: p.id,
-        order: index + 1,
-      })),
+      content: "",
+      problems: selectedProblems.value.map((p) => ({ ...p })),
     };
 
-    // 2) Mock DB에는 "문제 전체 객체"를 그대로 저장
-    const storePayload = {
-      id: boardId.value,
-      groupId: gid,
-      title: apiPayload.title,
-      deadline: apiPayload.deadline,
-      problems: [...selectedProblems.value],
-    };
+    await updateBoard(boardPayload);
 
-    updateBoard(storePayload); // TODO: integrate backend after boardApi.updateBoard(apiPayload);
-
-    // 3. 목록 데이터 갱신
     await fetchBoards(gid);
 
     // 4. 목록 페이지로 이동
@@ -238,6 +262,13 @@ async function handleSubmit() {
           </div>
         </section>
       </div>
+
+      <p
+        v-if="postError"
+        class="mt-3 text-sm text-red-500"
+      >
+        {{ postError }}
+      </p>
     </div>
   </div>
 </template>

--- a/src/components/board/SelectedProblemsPanel.vue
+++ b/src/components/board/SelectedProblemsPanel.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref } from "vue";
+import { ref, computed } from "vue";
+import { difficultyOptions } from "@/data/difficultyOptions";
 
 const props = defineProps({
   problems: {
@@ -33,6 +34,22 @@ function handleClearAll() {
   if (!ok) return;
   emit("clear-all");
 }
+
+const tierLabel = (difficulty) => {
+  if (difficulty === undefined || difficulty === null) return null;
+
+  // 문자열로 이미 들어오는 케이스(예: "Gold 5")면 그대로 라벨 처리
+  const direct = difficultyOptions.find((o) => o.value === String(difficulty));
+  if (direct) return direct.label;
+
+  const n = Number(difficulty);
+  if (!Number.isFinite(n)) return null;
+
+  const list = difficultyOptions.filter((o) => o.value !== "ALL"); // [Unrated, Bronze 5, ...]
+  return list[n]?.label ?? `난이도 ${n}`;
+};
+
+const displayProblems = computed(() => props.problems || []);
 </script>
 
 <template>
@@ -58,7 +75,7 @@ function handleClearAll() {
 
     <div class="selected-problems-list">
       <div
-        v-for="(problem, idx) in problems"
+        v-for="(problem, idx) in displayProblems"
         :key="problem.id"
         class="problem-slot"
         draggable="true"
@@ -66,16 +83,43 @@ function handleClearAll() {
         @dragover="handleDragOver"
         @drop="handleDrop(idx)"
       >
-        <div class="text-xs">
-          <span class="font-semibold mr-1">문제 {{ idx + 1 }}</span>
-          <span class="text-gray-600">{{ problem.title }}</span>
+        <!-- 왼쪽: 문제 번호 + 제목 + 티어 -->
+        <div class="min-w-0">
+          <!-- 1) 첫 줄: 문제번호 + 문제이름 -->
+          <div class="flex items-center gap-2">
+            <span class="text-xs font-semibold text-gray-700 shrink-0">
+              #{{ idx + 1 }}
+            </span>
+
+            <span class="text-xs font-medium text-gray-900 truncate">
+              {{ problem.title || `문제 ${problem.id}` }}
+            </span>
+          </div>
+
+          <!-- 2) 둘째 줄: ID + 난이도(ProblemSearch 스타일) -->
+          <div class="mt-0.5 flex items-center gap-2">
+            <span class="text-[10px] text-gray-400 truncate">
+              ID: {{ problem.id }}
+            </span>
+
+            <span
+              v-if="tierLabel(problem.difficulty)"
+              class="px-2 py-[2px] rounded-full bg-yellow-100 text-yellow-700 text-[11px] font-semibold shrink-0"
+              title="난이도"
+            >
+              {{ tierLabel(problem.difficulty) }}
+            </span>
+          </div>
         </div>
-        <div class="flex items-center gap-2">
+
+        <!-- 오른쪽: 링크 + 삭제 -->
+        <div class="flex items-center gap-2 shrink-0">
           <a
             :href="`https://www.acmicpc.net/problem/${problem.id}`"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center justify-center h-6 w-6 rounded-md border border-yellow-300 text-[11px] text-yellow-700 bg-yellow-50 hover:bg-yellow-100 hover:border-yellow-400 transition"
+            title="백준 문제 열기"
             @click.stop
           >
             ↗
@@ -85,6 +129,7 @@ function handleClearAll() {
             type="button"
             class="problem-remove-btn"
             aria-label="문제 제거"
+            title="선택 목록에서 제거"
             @click.stop="emit('remove', problem.id)"
           >
             ✕

--- a/src/config/apiMode.js
+++ b/src/config/apiMode.js
@@ -2,6 +2,7 @@ export const apiMode = {
   auth: import.meta.env.VITE_API_MODE_AUTH ?? "mock", // "mock" | "real"
   group: import.meta.env.VITE_API_MODE_GROUP ?? "mock",
   board: import.meta.env.VITE_API_MODE_BOARD ?? "mock",
+  boardStatus: import.meta.env.VITE_API_MODE_BOARD_STATUS ?? "mock",
   problem: import.meta.env.VITE_API_MODE_PROBLEM ?? "mock",
   member: import.meta.env.VITE_API_MODE_MEMBER ?? "mock",
 };

--- a/src/data/boardStore.js
+++ b/src/data/boardStore.js
@@ -14,42 +14,65 @@ export async function fetchBoards(groupId) {
 
 /**
  * 새 보드를 추가합니다.
- * - 기존 addBoard 이름을 유지 (호출부 영향 최소화)
+ *
+ * board:
+ *  - groupId: number
+ *  - requesterId: number
+ *  - title: string
+ *  - deadline?: string (datetime-local 값)
+ *  - content?: string
+ *  - problems: { id: number, ... }[]
  */
 export async function addBoard(board) {
-  const newBoard = await boardService.createBoard(board);
-  boards.value = [newBoard, ...boards.value];
-  return newBoard;
+  await boardService.createBoard(board);
 }
 
 /**
  * 보드를 삭제합니다.
+ *
+ * params:
+ *  - groupId: number
+ *  - boardId: number
+ *  - requesterId: number
  */
-export async function deleteBoard(boardId) {
-  await boardService.deleteBoard(boardId);
+export async function deleteBoard({ groupId, boardId, requesterId }) {
+  await boardService.deleteBoard({ groupId, boardId, requesterId });
+
   const numericId = Number(boardId);
   boards.value = boards.value.filter((b) => b.id !== numericId);
 }
 
 /**
  * 보드를 수정합니다.
+ *
+ * board:
+ *  - id: number
+ *  - groupId: number
+ *  - requesterId: number
+ *  - title: string
+ *  - deadline?: string
+ *  - content?: string
+ *  - problems: { id: number, ... }[]
  */
-export async function updateBoard(updatedBoard) {
-  const updated = await boardService.updateBoard(updatedBoard);
+export async function updateBoard(board) {
+  await boardService.updateBoard(board);
 
-  const index = boards.value.findIndex((b) => b.id == updated.id);
+  const numericId = Number(board.id);
+  const index = boards.value.findIndex((b) => b.id === numericId);
+
   if (index !== -1) {
-    boards.value.splice(index, 1, updated);
+    boards.value.splice(index, 1, {
+      ...boards.value[index],
+      ...board,
+    });
   }
-
-  return updated;
 }
 
 /**
  * 특정 보드의 상세 정보를 가져옵니다.
  */
-export async function fetchBoardById(boardId) {
-  return boardService.fetchBoardById(boardId);
+export async function fetchBoardById(groupId, boardId) {
+  return boardService.fetchBoardById(groupId, boardId);
 }
 
 /**

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -10,46 +10,151 @@ import {
 import { mockGetBoardUserStatus } from "@/mocks/boardUserStatus.mock";
 
 const USE_MOCK_BOARD = apiMode.board === "mock";
+const USE_MOCK_BOARD_STATUS = apiMode.boardStatus === "mock";
+
+/** datetime-local 값(YYYY-MM-DDTHH:mm)을 API 예시(초 포함)로 맞춤 */
+function toApiDateTime(v) {
+  if (!v) return null;
+  const s = String(v);
+  if (s.length === 16) return `${s}:00`; // 2025-12-20T17:04 -> 2025-12-20T17:04:00
+  if (s.length >= 19) return s.slice(0, 19); // 혹시 ms가 있어도 잘라줌
+  return s;
+}
+
+/** API에서 내려온 endTime(초 포함)을 datetime-local용(분까지만)으로 맞춤 */
+function toDatetimeLocal(v) {
+  if (!v) return "";
+  return String(v).slice(0, 16); // 2025-12-20T17:04:00 -> 2025-12-20T17:04
+}
+
+function nowDatetimeLocal() {
+  const d = new Date();
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function mapBoardSummaryFromApi(apiBoard, groupIdFromArg) {
+  return {
+    id: apiBoard.boardId,
+    groupId: groupIdFromArg ?? null, // 응답에 없으니 인자로 채워줌
+    title: apiBoard.title,
+    deadline: toDatetimeLocal(apiBoard.endTime),
+    problemsCount: apiBoard.problemsCount ?? 0,
+  };
+}
+
+function normalizeProblemSimpleDto(p) {
+  if (p == null) return null;
+
+  // 구버전: [1000, 1409] 같은 형태
+  if (typeof p === "number" || typeof p === "string") {
+    const id = Number(p);
+    return Number.isFinite(id) ? { id } : null;
+  }
+
+  // 신버전(swagger): [{ id, title, difficulty }]
+  const id = Number(p.id);
+  return {
+    id: Number.isFinite(id) ? id : null,
+    title: p.title ?? null,
+    difficulty: p.difficulty ?? null,
+  };
+}
+
+function mapBoardDetailFromApi(apiBoard) {
+  const problems = (apiBoard.problems || [])
+    .map(normalizeProblemSimpleDto)
+    .filter((p) => p && p.id != null);
+
+  return {
+    id: apiBoard.boardId,
+    groupId: apiBoard.groupId ?? null,
+    title: apiBoard.title,
+    content: apiBoard.content ?? "",
+    startTime: apiBoard.startTime ?? null,
+    endTime: apiBoard.endTime ?? null,
+
+    // ProblemBoard/BoardDetailView에서 쓰는 필드
+    deadline: apiBoard.endTime ?? null,
+    problems,
+    problemsCount: problems.length,
+  };
+}
+
+function buildCreateBodyFromBoard(board) {
+  // board: { title, deadline, content?, problems: {id}[] ... }
+  return {
+    title: board.title,
+    content: board.content ?? "",
+    startTime: toApiDateTime(nowDatetimeLocal()),
+    endTime: toApiDateTime(board.deadline),
+    problemIds: (board.problems || []).map((p) => p.id),
+  };
+}
+
+function buildUpdateBodyFromBoard(board) {
+  return {
+    title: board.title,
+    endTime: toApiDateTime(board.deadline),
+    problemIds: (board.problems || []).map((p) => p.id),
+  };
+}
 
 export const boardService = {
-  async fetchBoards(groupId) {
+  async fetchBoards(groupId, options) {
     if (USE_MOCK_BOARD) {
       return mockFetchBoards(groupId);
     }
-    return boardApi.fetchBoards(groupId);
+
+    const apiBoards = await boardApi.fetchBoards(groupId, options);
+    return apiBoards.map((b) => mapBoardSummaryFromApi(b, Number(groupId)));
   },
 
-  async fetchBoardById(boardId) {
+  async fetchBoardById(groupId, boardId) {
     if (USE_MOCK_BOARD) {
       return mockFetchBoardById(boardId);
     }
-    return boardApi.fetchBoardById(boardId);
+
+    const apiBoard = await boardApi.fetchBoardById(groupId, boardId);
+    return mapBoardDetailFromApi(apiBoard);
   },
 
   async createBoard(board) {
+    // board: { groupId, requesterId, title, deadline, content?, problems: [...] }
     if (USE_MOCK_BOARD) {
+      // mock DB는 전체 보드 객체를 그대로 저장
       return mockCreateBoard(board);
     }
-    return boardApi.createBoard(board);
+
+    const body = buildCreateBodyFromBoard(board);
+    return boardApi.createBoard(board.groupId, board.requesterId, body);
   },
 
-  async updateBoard(updatedBoard) {
+  async updateBoard(board) {
+    // board: { id, groupId, requesterId, title, deadline, content?, problems: [...] }
     if (USE_MOCK_BOARD) {
-      return mockUpdateBoard(updatedBoard);
+      return mockUpdateBoard(board);
     }
-    const { id, ...payload } = updatedBoard;
-    return boardApi.updateBoard(id, payload);
+
+    const body = buildUpdateBodyFromBoard(board);
+    return boardApi.updateBoard(
+      board.groupId,
+      board.id,
+      board.requesterId,
+      body,
+    );
   },
 
-  async deleteBoard(boardId) {
+  async deleteBoard({ groupId, boardId, requesterId }) {
     if (USE_MOCK_BOARD) {
       return mockDeleteBoard(boardId);
     }
-    return boardApi.deleteBoard(boardId);
+
+    return boardApi.deleteBoard(groupId, boardId, requesterId);
   },
 
   async getBoardUserStatus(groupId, boardId) {
-    if (USE_MOCK_BOARD) {
+    if (USE_MOCK_BOARD_STATUS) {
       return mockGetBoardUserStatus(groupId, boardId);
     }
     return boardApi.getBoardUserStatus(groupId, boardId);

--- a/src/views/BoardDetailView.vue
+++ b/src/views/BoardDetailView.vue
@@ -140,7 +140,7 @@ onMounted(async () => {
     const [, g, b, s] = await Promise.all([
       ensureMembersLoaded(1000),
       fetchGroupById(groupId),
-      fetchBoardById(boardId),
+      fetchBoardById(groupId, boardId),
       getBoardUserStatus(groupId, boardId),
     ]);
 

--- a/tests/BoardDetailView.spec.js
+++ b/tests/BoardDetailView.spec.js
@@ -146,7 +146,7 @@ describe("BoardDetailView.vue", () => {
     await flushPromises();
 
     expect(fetchGroupByIdMock).toHaveBeenCalledWith(1);
-    expect(fetchBoardByIdMock).toHaveBeenCalledWith(10);
+    expect(fetchBoardByIdMock).toHaveBeenCalledWith(1, 10);
     expect(getBoardUserStatusMock).toHaveBeenCalledWith(1, 10);
 
     expect(wrapper.text()).toContain("2023년 상반기 회고");

--- a/tests/BoardList.spec.js
+++ b/tests/BoardList.spec.js
@@ -55,8 +55,8 @@ vi.mock("@/data/groupStore", () => {
 vi.mock("@/data/boardStore", () => {
   const boards = ref([]);
 
-  const deleteBoard = vi.fn((id) => {
-    boards.value = boards.value.filter((b) => b.id !== id);
+  const deleteBoard = vi.fn(({ boardId }) => {
+    boards.value = boards.value.filter((b) => b.id !== boardId);
   });
 
   const fetchBoards = vi.fn(async () => {
@@ -228,7 +228,11 @@ describe("BoardList.vue", () => {
 
     // 1) 동작 검증
     expect(confirmSpy).toHaveBeenCalled();
-    expect(deleteBoardMock).toHaveBeenCalledWith(1);
+    expect(deleteBoardMock).toHaveBeenCalledWith({
+      groupId: 1,
+      boardId: 1,
+      requesterId: 1,
+    });
     expect(fetchBoardsMock).toHaveBeenCalledWith(1);
 
     // 2) store 상태에서 사라졌는지

--- a/tests/ProblemBoard.spec.js
+++ b/tests/ProblemBoard.spec.js
@@ -1,9 +1,9 @@
 import { mount, flushPromises } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { nextTick } from "vue";
-import ProblemBoard from "../src/components/ProblemBoard.vue";
-import { problemService } from "@/services/problemService";
-import { addBoard, fetchBoards } from "../src/data/boardStore";
+import { nextTick, ref } from "vue";
+// import ProblemBoard from "../src/components/ProblemBoard.vue";
+// import { problemService } from "@/services/problemService";
+// import { addBoard, fetchBoards } from "../src/data/boardStore";
 
 // 1) vue-router mock
 const pushMock = vi.fn();
@@ -14,7 +14,20 @@ vi.mock("vue-router", () => ({
   useRoute: () => ({ params: routeParams }),
 }));
 
-// 2) boardStore mock (addBoard, fetchBoards 등)
+// =======================
+// 2) authStore mock
+//    - ProblemBoard.vue는 currentUserId가 없으면 early return 함
+// =======================
+vi.mock("../src/data/authStore", () => {
+  const user = ref({ id: 1, name: "테스트 유저" });
+  return {
+    useAuthStore: () => ({ user }),
+  };
+});
+
+// =======================
+// 3) boardStore mock (ProblemBoard가 실제로 호출하는 것들)
+// =======================
 vi.mock("../src/data/boardStore", () => ({
   addBoard: vi.fn(),
   updateBoard: vi.fn(),
@@ -22,21 +35,20 @@ vi.mock("../src/data/boardStore", () => ({
   fetchBoardById: vi.fn(),
 }));
 
+// =======================
+// 4) SUT & mocked exports import
+//    - mock 선언 이후에 import
+// =======================
+import ProblemBoard from "../src/components/ProblemBoard.vue";
+import { addBoard, fetchBoards } from "../src/data/boardStore";
+
 describe("ProblemBoard.vue", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    pushMock.mockClear();
-    addBoard.mockClear();
-    fetchBoards.mockClear();
     Object.assign(routeParams, { groupId: "1" }); // 기본은 create 모드
   });
 
   it("게시 버튼 클릭 시 postBoard 를 올바른 payload 로 호출한다", async () => {
-    // postBoard 모킹
-    const mockPost = vi
-      .spyOn(problemService, "postBoard")
-      .mockResolvedValue({ id: 999, success: true });
-
     const wrapper = mount(ProblemBoard, {
       global: {
         // 3) 자식 컴포넌트들은 stub 으로 단순화
@@ -91,17 +103,29 @@ describe("ProblemBoard.vue", () => {
     // 5) BoardHeader stub 의 submit 버튼 클릭 → ProblemBoard 의 handleSubmit → handlePost 실행
     const submitButton = wrapper.get('[data-test="submit"]');
     await submitButton.trigger("click");
-    await nextTick();
+    await flushPromises();
 
     // 6) postBoard 호출 검증
-    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(addBoard).toHaveBeenCalledTimes(1);
 
-    const payload = mockPost.mock.calls[0][0];
+    const payload = addBoard.mock.calls[0][0];
     expect(payload.title).toBe("테스트 세션");
     expect(payload.deadline).toBeNull(); // deadline 안 넣었으니 null
     expect(payload.problems).toEqual([
-      { id: 1, order: 1 },
-      { id: 2, order: 2 },
+      {
+        id: 1,
+        title: "A",
+        difficulty: "Gold 5",
+        tags: [],
+        acceptedUserCount: 1,
+      },
+      {
+        id: 2,
+        title: "B",
+        difficulty: "Gold 4",
+        tags: [],
+        acceptedUserCount: 1,
+      },
     ]);
   });
 
@@ -126,11 +150,6 @@ describe("ProblemBoard.vue", () => {
   });
 
   it("게시 성공 시 addBoard/fetchBoards/router.push를 groupId로 호출한다", async () => {
-    vi.spyOn(problemService, "postBoard").mockResolvedValue({
-      id: 999,
-      success: true,
-    });
-
     const wrapper = mount(ProblemBoard, {
       global: {
         stubs: {
@@ -141,6 +160,7 @@ describe("ProblemBoard.vue", () => {
           },
           SelectedProblemsPanel: { template: "<div />", props: ["problems"] },
           BoardHeader: {
+            name: "BoardHeader",
             template: `<button data-test="submit" @click="$emit('submit')">게시</button>`,
           },
         },
@@ -173,9 +193,6 @@ describe("ProblemBoard.vue", () => {
     await flushPromises();
 
     expect(addBoard).toHaveBeenCalledTimes(1);
-    expect(addBoard).toHaveBeenCalledWith(
-      expect.objectContaining({ groupId: 1, id: 999, title: "테스트 세션" }),
-    );
 
     expect(fetchBoards).toHaveBeenCalledTimes(1);
     expect(fetchBoards).toHaveBeenCalledWith(1);
@@ -188,10 +205,6 @@ describe("ProblemBoard.vue", () => {
   });
 
   it("title/selectedProblems가 부족하면 postBoard를 호출하지 않는다", async () => {
-    const postSpy = vi
-      .spyOn(problemService, "postBoard")
-      .mockResolvedValue({ id: 1 });
-
     const wrapper = mount(ProblemBoard, {
       global: {
         stubs: {
@@ -206,8 +219,10 @@ describe("ProblemBoard.vue", () => {
 
     // 아무것도 세팅 안함 -> canPost=false
     await wrapper.get('[data-test="submit"]').trigger("click");
-    await nextTick();
+    await flushPromises();
 
-    expect(postSpy).not.toHaveBeenCalled();
+    expect(addBoard).not.toHaveBeenCalled();
+    expect(fetchBoards).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/41
---

## ✅ 구현 내용

* **Board API 경로/시그니처를 그룹 스코프 기반으로 통일**

  * `/api/v1/groups/{groupId}/boards` 규격에 맞춰 `boardApi`/`boardService`/`boardStore`/UI 호출부를 정렬
* **boardStatus API 모드 분리**

  * `apiMode.boardStatus` 추가로 `board CRUD`와 `board userStatus`의 mock/real 모드를 독립적으로 제어
* **Board 생성/수정/삭제에 requesterId 반영**

  * `deleteBoard({ groupId, boardId, requesterId })` 등 payload 기반 호출로 변경
  * 미로그인 시 early return 처리(UX 보호)
* **BoardDetailView fetchBoardById 호출 인자 수정**

  * `fetchBoardById(groupId, boardId)`로 교정
* **ProblemBoard 안정화**

  * 선택 문제 데이터 normalize 로직 추가(구버전/예외 케이스 방어)
  * create/update 시 requesterId 포함 + content 임시 처리
* **SelectedProblemsPanel UI 개선**

  * `difficultyOptions` 기반 티어 배지 표시(ProblemSearch 스타일과 톤 정합)
* **테스트 업데이트**

  * 변경된 함수 시그니처/호출 인자에 맞춰 BoardDetailView/BoardList/ProblemBoard spec 수정

---

## 📂 변경 모듈

* `src/config/apiMode.js`

  * `boardStatus` env flag 추가
* `src/api/boardApi.js`

  * 그룹 스코프 엔드포인트(`/groups/{groupId}/boards...`) 정렬 + query 지원
* `src/services/boardService.js`

  * real API 응답/요청 매핑
  * datetime-local ↔ API datetime 변환 유틸
  * `boardStatus` 모드 분리
* `src/data/boardStore.js`

  * CRUD 시그니처를 `groupId/requesterId` 기반으로 통일
* `src/components/BoardList.vue`

  * 삭제 시 payload 방식으로 호출 + 로그인 가드
* `src/components/ProblemBoard.vue`

  * requesterId 반영 + selectedProblems normalize + 에러 메시지 렌더링
* `src/components/board/SelectedProblemsPanel.vue`

  * 난이도 배지 렌더링
* `src/views/BoardDetailView.vue`

  * `fetchBoardById(groupId, boardId)` 호출로 수정
* `tests`

  * `BoardDetailView.spec.js`
  * `BoardList.spec.js`
  * `ProblemBoard.spec.js`

---

## 🧪 시나리오

### 1) BoardList

* [ ] 그룹 진입 시 보드 목록 정상 로드
* [ ] 진행/지난 탭 전환 시 필터링 정상 동작
* [ ] 검색어 입력 시 제목 필터 정상 동작
* [ ] **권한 사용자**: 보드 생성/수정/삭제 버튼 노출
* [ ] **미권한 사용자**: 생성/수정/삭제 버튼 미노출
* [ ] **삭제 플로우**

  * [ ] 로그인 상태: confirm → `deleteBoard({ groupId, boardId, requesterId })` 호출 → 목록 갱신
  * [ ] 미로그인 상태: “로그인이 필요합니다.” 안내 후 종료

### 2) ProblemBoard (Create/Edit)

* [ ] 보드 생성 시 requesterId 포함하여 API 호출/스토어 업데이트 흐름 정상
* [ ] 보드 수정 시 requesterId 포함하여 API 호출/스토어 업데이트 흐름 정상
* [ ] 선택 문제 데이터가 구버전 형태로 들어와도 normalize되어 정상 렌더/전송
* [ ] 제목/선택문제 부족 시 submit 방지

### 3) SelectedProblemsPanel

* [ ] 문제 제목/ID 표시 정상
* [ ] 난이도 값이 숫자/문자열 모두 들어와도 티어 배지 표시 정상

### 4) BoardDetailView

* [ ] 마운트 시 `fetchBoardById(groupId, boardId)` 및 status 호출 정상
* [ ] 문제 기준 보기 / 사용자 기준 보기 전환 정상
* [ ] 내 현황만 보기 토글 및 로그인/비로그인 상태 처리 정상

---

## 💡 기타

* **TODO**

  * `getBoardUserStatus` real endpoint 경로(`/api/v1/...`) 정식 스펙 반영 필요(현재 일부 TODO/레거시 경로 혼재 가능)
  * Board `content` UI(textarea) 추가 시 payload 연동 정리
* **리스크/주의**

  * real API 응답 필드(boardId/endTime 등) 매핑에 의존 → 백엔드 스펙 변경 시 영향 큼


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 그룹 단위 보드 경로 지원 및 보드 문제 조회 기능 추가

* **버그 수정**
  * 보드 삭제/수정/등록 시 비로그인 차단 및 인증 검사 추가

* **개선 사항**
  * 보드 생성·수정·삭제 흐름에 그룹 컨텍스트 반영
  * 문제 선택 정규화 및 중복 제거 로직 개선
  * 서버 유효성/오류 메시지 표시 강화

* **테스트**
  * 인증 및 그룹 컨텍스트를 반영한 테스트 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->