### PR TITLE
[BSM-42] refactor: align getBoardUserStatus flow with swagger spec

### DIFF
--- a/src/api/boardApi.js
+++ b/src/api/boardApi.js
@@ -93,14 +93,14 @@ export async function getBoardProblems(groupId, boardId) {
   return res.data; // number[]
 }
 
-// TODO: Swagger
 /**
  * 보드별 유저 풀이 현황
- * GET /api/v1/groups/{groupId}/boards/{boardId}/userStatus
+ * GET /api/v1/groups/{groupId}/boards/{boardId}/userStatus?requesterId=...
  */
-export async function getBoardUserStatus(groupId, boardId) {
+export async function getBoardUserStatus({ groupId, boardId, requesterId }) {
   const res = await httpClient.get(
-    `/v1/groups/${groupId}/boards/${boardId}/userStatus`,
+    `/groups/${groupId}/boards/${boardId}/userStatus`,
+    { params: { requesterId } },
   );
   return res.data;
 }

--- a/src/data/boardStore.js
+++ b/src/data/boardStore.js
@@ -70,6 +70,9 @@ export async function updateBoard(board) {
 
 /**
  * 특정 보드의 상세 정보를 가져옵니다.
+ *  params:
+ *  - groupId: number
+ *  - boardId: number
  */
 export async function fetchBoardById(groupId, boardId) {
   return boardService.fetchBoardById(groupId, boardId);
@@ -77,7 +80,11 @@ export async function fetchBoardById(groupId, boardId) {
 
 /**
  * 보드별 유저 풀이 현황 조회
+ * params:
+ *  - groupId: number
+ *  - boardId: number
+ *  - requesterId: number
  */
-export async function getBoardUserStatus(groupId, boardId) {
-  return boardService.getBoardUserStatus(groupId, boardId);
+export async function getBoardUserStatus({ groupId, boardId, requesterId }) {
+  return boardService.getBoardUserStatus({ groupId, boardId, requesterId });
 }

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -33,6 +33,21 @@ function nowDatetimeLocal() {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+function mapBoardProgressFromApi(api) {
+  return {
+    boardId: api.boardId ?? null,
+    problemStatus: (api.problemStatus || []).map((p) => ({
+      problemId: p.problemId,
+      solvedUsers: (p.solvedUserIds || []).map(Number),
+    })),
+    userStatus: (api.userStatus || []).map((u) => ({
+      userId: u.userId,
+      username: u.username ?? null,
+      solvedProblems: (u.solvedProblemIds || []).map(Number),
+    })),
+  };
+}
+
 function mapBoardSummaryFromApi(apiBoard, groupIdFromArg) {
   return {
     id: apiBoard.boardId,
@@ -75,7 +90,7 @@ function mapBoardDetailFromApi(apiBoard) {
     endTime: apiBoard.endTime ?? null,
 
     // ProblemBoard/BoardDetailView에서 쓰는 필드
-    deadline: apiBoard.endTime ?? null,
+    deadline: toDatetimeLocal(apiBoard.endTime),
     problems,
     problemsCount: problems.length,
   };
@@ -153,10 +168,16 @@ export const boardService = {
     return boardApi.deleteBoard(groupId, boardId, requesterId);
   },
 
-  async getBoardUserStatus(groupId, boardId) {
+  async getBoardUserStatus({ groupId, boardId, requesterId }) {
     if (USE_MOCK_BOARD_STATUS) {
       return mockGetBoardUserStatus(groupId, boardId);
     }
-    return boardApi.getBoardUserStatus(groupId, boardId);
+
+    const apiRes = await boardApi.getBoardUserStatus(
+      groupId,
+      boardId,
+      requesterId,
+    );
+    return mapBoardProgressFromApi(apiRes);
   },
 };

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -173,11 +173,11 @@ export const boardService = {
       return mockGetBoardUserStatus(groupId, boardId);
     }
 
-    const apiRes = await boardApi.getBoardUserStatus(
+    const apiRes = await boardApi.getBoardUserStatus({
       groupId,
       boardId,
       requesterId,
-    );
+    });
     return mapBoardProgressFromApi(apiRes);
   },
 };

--- a/src/views/BoardDetailView.vue
+++ b/src/views/BoardDetailView.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useAuthStore } from "../data/authStore";
 import { fetchBoardById } from "../data/boardStore";
 import { fetchGroupById } from "../data/groupStore";
-import { members, ensureMembersLoaded } from "@/data/memberStore";
+import { members } from "@/data/memberStore";
 import { getBoardUserStatus } from "@/data/boardStore";
 
 const route = useRoute();
@@ -31,17 +31,29 @@ function toNumber(v) {
 
 // 그룹 참여자 목록 (owner + managers + members)
 const participants = computed(() => {
+  const list = (status.value?.userStatus || [])
+    .map((u) => {
+      const id = toNumber(u.userId);
+      if (id == null) return null;
+
+      const username = u.username ?? ""; // swager
+      return {
+        id,
+        name: username || `user-${id}`,
+        nickname: username,
+      };
+    })
+    .filter(Boolean);
+
+  // userStatus가 비어있을 때만 group+memberStore 방식으로 fallback
+  if (list.length) return list;
+
   if (!group.value) return [];
-
   const idSet = new Set();
-
-  if (group.value.ownerId != null) {
-    idSet.add(toNumber(group.value.ownerId));
-  }
+  if (group.value.ownerId != null) idSet.add(toNumber(group.value.ownerId));
   (group.value.managerIds || []).forEach((id) => idSet.add(toNumber(id)));
   (group.value.memberIds || []).forEach((id) => idSet.add(toNumber(id)));
 
-  // memberStore에 있는 유저 데이터에서 필터
   return members.value.filter((m) => idSet.has(toNumber(m.id)));
 });
 
@@ -68,7 +80,8 @@ const problemSolvedMap = computed(() => {
   if (!status.value?.problemStatus) return map;
 
   status.value.problemStatus.forEach((p) => {
-    const set = new Set((p.solvedUsers || []).map(toNumber));
+    const ids = p.solvedUserIds ?? p.solvedUsers ?? [];
+    const set = new Set(ids.map(toNumber));
     map.set(toNumber(p.problemId), set);
   });
 
@@ -81,7 +94,8 @@ const userSolvedMap = computed(() => {
   if (!status.value?.userStatus) return map;
 
   status.value.userStatus.forEach((u) => {
-    const set = new Set((u.solvedProblems || []).map(toNumber));
+    const ids = u.solvedProblemIds ?? u.solvedProblems ?? [];
+    const set = new Set(ids.map(toNumber));
     map.set(toNumber(u.userId), set);
   });
 
@@ -134,14 +148,17 @@ onMounted(async () => {
   error.value = "";
 
   try {
-    const groupId = route.params.groupId;
-    const boardId = route.params.boardId;
+    const gid = Number(route.params.groupId);
+    const bid = Number(route.params.boardId);
 
-    const [, g, b, s] = await Promise.all([
-      ensureMembersLoaded(1000),
-      fetchGroupById(groupId),
-      fetchBoardById(groupId, boardId),
-      getBoardUserStatus(groupId, boardId),
+    const [g, b, s] = await Promise.all([
+      fetchGroupById(gid),
+      fetchBoardById(gid, bid),
+      getBoardUserStatus({
+        groupId: gid,
+        boardId: bid,
+        requesterId: Number(currentUserId.value),
+      }),
     ]);
 
     group.value = g;

--- a/src/views/BoardDetailView.vue
+++ b/src/views/BoardDetailView.vue
@@ -157,7 +157,7 @@ onMounted(async () => {
       getBoardUserStatus({
         groupId: gid,
         boardId: bid,
-        requesterId: Number(currentUserId.value),
+        requesterId: currentUserId.value ? Number(currentUserId.value) : null,
       }),
     ]);
 

--- a/src/views/BoardDetailView.vue
+++ b/src/views/BoardDetailView.vue
@@ -36,7 +36,7 @@ const participants = computed(() => {
       const id = toNumber(u.userId);
       if (id == null) return null;
 
-      const username = u.username ?? ""; // swager
+      const username = u.username ?? ""; // swagger
       return {
         id,
         name: username || `user-${id}`,

--- a/tests/BoardDetailView.spec.js
+++ b/tests/BoardDetailView.spec.js
@@ -99,13 +99,13 @@ const sampleBoard = {
 
 const sampleStatus = {
   problemStatus: [
-    { problemId: 1008, solvedUsers: [1, 2] },
-    { problemId: 1009, solvedUsers: [1, 3] },
+    { problemId: 1008, solvedUserIds: [1, 2] },
+    { problemId: 1009, solvedUserIds: [1, 3] },
   ],
   userStatus: [
-    { userId: 1, solvedProblems: [1008, 1009] },
-    { userId: 2, solvedProblems: [1008] },
-    { userId: 3, solvedProblems: [1009] },
+    { userId: 1, username: "이알고", solvedProblemIds: [1008, 1009] },
+    { userId: 2, username: "달피곰", solvedProblemIds: [1008] },
+    { userId: 3, username: "집에갈까요", solvedProblemIds: [1009] },
   ],
 };
 
@@ -147,7 +147,11 @@ describe("BoardDetailView.vue", () => {
 
     expect(fetchGroupByIdMock).toHaveBeenCalledWith(1);
     expect(fetchBoardByIdMock).toHaveBeenCalledWith(1, 10);
-    expect(getBoardUserStatusMock).toHaveBeenCalledWith(1, 10);
+    expect(getBoardUserStatusMock).toHaveBeenCalledWith({
+      groupId: 1,
+      boardId: 10,
+      requesterId: 1,
+    });
 
     expect(wrapper.text()).toContain("2023년 상반기 회고");
     expect(wrapper.text()).toContain("CS 면접 대비반");


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/42
---

✅ 구현 내용

* Swagger 스펙(`/api/v1/groups/{groupId}/boards/{boardId}/userStatus?requesterId=...`)에 맞게 `getBoardUserStatus` 호출 체인(boardApi → boardService → boardStore → BoardDetailView)을 정합성 있게 변경했습니다.
* `BoardDetailView`의 참여자 컬럼이 `memberStore.members` 의존으로 비어버리던 문제를 해결하기 위해, `boardStatus.userStatus[].username` 기반으로 참여자 목록을 구성하도록 수정했습니다.
* 테스트(`BoardDetailView.spec`)는 변경된 시그니처(객체 파라미터)와 Swagger 응답 필드(`username`, `solvedUserIds`, `solvedProblemIds`)에 맞게 업데이트했습니다.

📂 변경 모듈

* `src/api/boardApi.js`

  * `getBoardUserStatus` endpoint 및 query(requesterId) 반영
* `src/services/boardService.js`

  * boardStatus 응답 매핑/호환 처리 (username/solved*Ids)
* `src/data/boardStore.js`

  * `getBoardUserStatus` 호출 시그니처 통일(객체 파라미터)
* `src/views/BoardDetailView.vue`

  * 참여자(participants) 구성 로직을 boardStatus 기반으로 변경 + fallback 유지
* `tests/BoardDetailView.spec.js`

  * `getBoardUserStatus` 호출 인자 및 mock 응답을 Swagger 스키마로 업데이트

🧪 시나리오

* [x] BoardDetailView 진입 시 `fetchGroupById / fetchBoardById / getBoardUserStatus`가 올바른 인자로 호출된다
* [x] 문제 기준 보기에서 참여자 컬럼(유저 이름/닉네임)이 정상 렌더링된다
* [x] 사용자 기준 보기에서 사용자 카드와 완료율이 정상 렌더링된다
* [x] “내 현황만 보기” 토글 시 현재 로그인 유저만 표시된다
* [x] 로그인하지 않은 경우 “내 현황만 보기” 비활성화 및 “내 완료율” 카드 미노출

💡 기타

* `memberStore.members` 로딩/동기화가 지연되거나 비어 있어도, 보드 유저현황 API가 username을 제공하므로 UI가 안정적으로 렌더링 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 보드 사용자 상태 조회 호출 방식이 변경되어 요청에 requesterId를 함께 전달하도록 개선되었습니다.
  * 보드 상세 화면의 참여자 목록 생성 로직이 사용자 상태 정보를 우선 반영하도록 최적화되었습니다.
  * 마감일 표시 형식이 더 일관된 날짜/시간으로 개선되었습니다.

* **테스트**
  * 관련 테스트들이 새로운 호출 방식과 데이터 형태에 맞춰 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->