### PR TITLE
[BSM-40] fix: pass requesterId to fetchGroupById for group permission checks

### DIFF
--- a/src/api/groupApi.js
+++ b/src/api/groupApi.js
@@ -2,58 +2,150 @@ import httpClient from "./httpClient";
 
 /**
  * GET /api/v1/groups
- * 그룹 리스트 조회
+ *
+ * 쿼리:
+ *  - requesterId: number (required)
+ *  - name: string (optional, 검색어)
+ *
+ * 응답: GroupSummaryResponse[]
  */
-export async function fetchGroups() {
-  const res = await httpClient.get("/v1/groups");
+export async function fetchGroups({ requesterId, name } = {}) {
+  const res = await httpClient.get("/groups", {
+    params: {
+      requesterId,
+      name,
+    },
+  });
   return res.data;
 }
 
 /**
  * DELETE /api/v1/groups/{groupId}/members/me
- * 현재 로그인한 사용자가 그룹에서 탈퇴
+ *
+ * 쿼리:
+ *  - requesterId: number
+ *
+ * 응답: BasicResponse { success: boolean }
  */
-export async function leaveGroup(groupId) {
-  const res = await httpClient.delete(`/v1/groups/${groupId}/members/me`);
-  return res.data;
+export async function leaveGroup({ groupId, requesterId }) {
+  const res = await httpClient.delete(`/groups/${groupId}/members/me`, {
+    params: { requesterId },
+  });
+  return res.data; // BasicResponse
 }
 
 /**
  * POST /api/v1/groups
- * 새 그룹 생성
+ *
+ * 쿼리:
+ *  - requesterId: number (required)
+ *
+ * Body: GroupCreateRequest
+ *  {
+ *    title: string,
+ *    managerIds: number[],
+ *    memberIds: number[],
+ *    visibility: string,
+ *    description: string
+ *  }
+ *
+ * 응답: BasicResponse { success: boolean }
  */
-export async function createGroup(payload) {
-  const res = await httpClient.post("/v1/groups", payload);
-  return res.data;
+export async function createGroup({
+  requesterId,
+  title,
+  managerIds,
+  memberIds,
+  visibility,
+  description,
+}) {
+  const res = await httpClient.post(
+    "/groups",
+    {
+      title,
+      managerIds,
+      memberIds,
+      visibility,
+      description,
+    },
+    {
+      params: { requesterId },
+    },
+  );
+  return res.data; // BasicResponse
 }
 
 /**
  * GET /api/v1/groups/{groupId}
  * 그룹 상세 조회
  */
-export async function fetchGroupById(groupId) {
-  const res = await httpClient.get(`/v1/groups/${groupId}`);
+export async function fetchGroupById(groupId, { requesterId } = {}) {
+  const res = await httpClient.get(`/groups/${groupId}/detail`, {
+    params: { requesterId },
+  });
   return res.data;
 }
 
 /**
- * PUT /api/v1/groups/{groupId}
- * 그룹 수정
+ * PATCH /api/v1/groups/{groupId}
+ * query: requesterId
+ * body: GroupUpdateRequest
  */
-export async function updateGroup(groupId, payload) {
-  const res = await httpClient.put(`/v1/groups/${groupId}`, payload);
-  return res.data;
+export async function updateGroup({
+  groupId,
+  requesterId,
+  title,
+  visibility,
+  description,
+  managerIds,
+  memberIds,
+} = {}) {
+  const body = {
+    title,
+    visibility,
+    description,
+  };
+
+  if (Array.isArray(managerIds)) body.managerIds = managerIds;
+  if (Array.isArray(memberIds)) body.memberIds = memberIds;
+
+  const res = await httpClient.patch(`/groups/${groupId}`, body, {
+    params: { requesterId },
+  });
+
+  return res.data; // BasicResponse or updated object
 }
 
 /**
- * POST /api/v1/groups/{groupId}/owner
- * 그룹 소유자 변경
- * (실제 백엔드 스펙에 맞게 엔드포인트/메서드는 나중에 조정)
+ * PATCH /api/v1/groups/{groupId}/owner
+ *
+ * 쿼리:
+ *  - requesterId: number
+ *
+ * Body: OwnerChangeRequest { newOwnerId }
+ *
+ * 응답: BasicResponse { success: boolean }
  */
-export async function changeGroupOwner(groupId, { requesterId, newOwnerId }) {
-  const res = await httpClient.post(`/v1/groups/${groupId}/owner`, {
-    requesterId,
-    newOwnerId,
+export async function changeGroupOwner({ groupId, requesterId, newOwnerId }) {
+  const res = await httpClient.patch(
+    `/groups/${groupId}/owner`,
+    { newOwnerId },
+    {
+      params: { requesterId },
+    },
+  );
+  return res.data; // BasicResponse
+}
+
+/**
+ * GET /api/v1/groups/{groupId}/users
+ * 그룹 유저 목록 조회
+ * query: requesterId
+ * resp: GroupUserDto[]
+ */
+export async function fetchGroupUsers(groupId, { requesterId } = {}) {
+  const res = await httpClient.get(`/groups/${groupId}/users`, {
+    params: { requesterId },
   });
   return res.data;
 }

--- a/src/data/groupStore.js
+++ b/src/data/groupStore.js
@@ -4,37 +4,54 @@ import { groupService } from "@/services/groupService";
 export const groups = ref([]);
 
 /**
- *   그룹 목록 조회
+ * 그룹 목록 조회
+ * @param {{ requesterId?: number, name?: string }} options
  */
-export async function fetchGroups() {
-  const list = await groupService.fetchGroups();
+export async function fetchGroups(options = {}) {
+  const list = await groupService.fetchGroups(options);
   groups.value = [...list];
   return groups.value;
 }
 
 /**
  * 현재 로그인한 사용자가 그룹에서 탈퇴
+ * - mock/real 모두 여기서 state 제거까지 처리
  */
-export async function leaveGroup(groupId) {
+export async function leaveGroup(groupId, options = {}) {
   const numericId = Number(groupId);
-  await groupService.leaveGroup(numericId);
+
+  await groupService.leaveGroup(numericId, options);
+
+  // 로컬 상태에서도 제거
   groups.value = groups.value.filter((g) => g.id !== numericId);
 }
 
 /**
  * 새 그룹 생성
+ *
+ * - mock 모드:
+ *    groupService.createGroup → 새 그룹 객체 반환
+ *    → 여기서 groups 앞에 unshift
+ * - real 모드:
+ *    BasicResponse { success } 형태면 state는 건드리지 않고
+ *    호출자(뷰)에서 fetchGroups를 다시 호출하는 패턴 추천
  */
 export async function createGroup(payload) {
   const newGroup = await groupService.createGroup(payload);
-  groups.value = [newGroup, ...groups.value];
+
+  if (newGroup && typeof newGroup === "object" && "id" in newGroup) {
+    // mock 모드일 때만 동작 (newGroup가 실제 그룹 객체인 경우)
+    groups.value = [newGroup, ...groups.value];
+  }
+
   return newGroup;
 }
 
 /**
  * 그룹 하나 상세 조회
  */
-export async function fetchGroupById(groupId) {
-  return groupService.fetchGroupById(groupId);
+export async function fetchGroupById(groupId, options = {}) {
+  return groupService.fetchGroupById(groupId, options);
 }
 
 /**
@@ -43,11 +60,14 @@ export async function fetchGroupById(groupId) {
 export async function updateGroup(groupId, payload) {
   const updated = await groupService.updateGroup(groupId, payload);
 
-  const numericId = Number(groupId);
-  const index = groups.value.findIndex((g) => g.id === numericId);
+  // mock 모드(그룹 객체 반환) 일 때만 state 반영
+  if (updated && typeof updated === "object" && "id" in updated) {
+    const numericId = Number(groupId);
+    const index = groups.value.findIndex((g) => g.id === numericId);
 
-  if (index === -1) {
-    groups.value.splice(index, 1, updated);
+    if (index !== -1) {
+      groups.value.splice(index, 1, updated);
+    }
   }
 
   return updated;
@@ -62,12 +82,21 @@ export async function changeGroupOwner(groupId, { requesterId, newOwnerId }) {
     newOwnerId,
   });
 
-  const numericId = Number(groupId);
-  const index = groups.value.findIndex((g) => g.id === numericId);
+  if (updated && typeof updated === "object" && "id" in updated) {
+    const numericId = Number(groupId);
+    const index = groups.value.findIndex((g) => g.id === numericId);
 
-  if (index === -1) {
-    groups.value.splice(index, 1, updated);
+    if (index !== -1) {
+      groups.value.splice(index, 1, updated);
+    }
   }
 
   return updated;
+}
+
+/**
+ * 그룹 사용자 목록 조회
+ */
+export async function fetchGroupUsers(groupId, options = {}) {
+  return groupService.fetchGroupUsers(groupId, options);
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -150,9 +150,19 @@ router.beforeEach(async (to, from, next) => {
       return next({ name: "GroupList" });
     }
 
+    const userId = auth.user.value?.id;
+    if (!userId) {
+      return next({
+        name: "Login",
+        query: { redirect: to.fullPath },
+        replace: true,
+      });
+    }
+    const uid = Number(userId);
+
     let group;
     try {
-      group = await fetchGroupById(groupId);
+      group = await fetchGroupById(groupId, { requesterId: uid });
     } catch (e) {
       console.error("[router] fetchGroupById error:", e);
       window.alert("그룹 정보를 불러올 수 없습니다.");
@@ -164,16 +174,6 @@ router.beforeEach(async (to, from, next) => {
       return next({ name: "GroupList" });
     }
 
-    const userId = auth.user.value?.id;
-    if (!userId) {
-      return next({
-        name: "Login",
-        query: { redirect: to.fullPath },
-        replace: true,
-      });
-    }
-
-    const uid = Number(userId);
     const ownerId = group.ownerId != null ? Number(group.ownerId) : null;
     const managerIds = Array.isArray(group.managerIds)
       ? group.managerIds.map(Number)

--- a/src/services/groupService.js
+++ b/src/services/groupService.js
@@ -11,46 +11,251 @@ import {
 
 const USE_MOCK_GROUP = apiMode.group === "mock";
 
+const toNumArr = (arr) => (Array.isArray(arr) ? arr.map((v) => Number(v)) : []);
+const uniqNums = (arr) =>
+  Array.from(new Set(toNumArr(arr))).filter((n) => Number.isFinite(n));
+
+export function mapGroupDetailFromApi(api) {
+  return {
+    id: api.id,
+    name: api.title ?? api.name ?? "",
+    description: api.description ?? "",
+    ownerId: api.ownerId != null ? Number(api.ownerId) : null,
+    managerIds: toNumArr(api.managers ?? api.managerIds),
+    memberIds: toNumArr(api.members ?? api.memberIds),
+    visibility: api.visibility ?? "PRIVATE",
+    createdAt: api.createdAt,
+    updatedAt: api.updatedAt,
+  };
+}
+
 export const groupService = {
-  async fetchGroups() {
+  /**
+   * 그룹 목록 조회
+   * @param {{ requesterId?: number, name?: string }} options
+   */
+  async fetchGroups(options = {}) {
     if (USE_MOCK_GROUP) {
+      // mock에서는 requesterId 없이도 동작
       return mockFetchGroups();
     }
-    return groupApi.fetchGroups();
+
+    const { requesterId, name } = options;
+    if (!requesterId) {
+      throw new Error(
+        "groupService.fetchGroups: real 모드에서는 requesterId가 필요합니다.",
+      );
+    }
+
+    // GroupSummaryResponse[]
+    const list = await groupApi.fetchGroups({ requesterId, name });
+
+    // FE에서 쓰기 좋은 형태로 매핑
+    return list.map((g) => ({
+      id: g.id,
+      name: g.title, // title -> name
+      ownerId: g.ownerId,
+      visibility: g.visibility,
+      memberCount: g.memberCount,
+      createdAt: g.createdAt,
+      updatedAt: g.updatedAt,
+      description: g.description ?? "",
+    }));
   },
 
-  async leaveGroup(groupId) {
+  /**
+   * 그룹 탈퇴 (현재 로그인 유저 기준)
+   */
+  async leaveGroup(groupId, options = {}) {
     if (USE_MOCK_GROUP) {
       return mockLeaveGroup(groupId);
     }
-    return groupApi.leaveGroup(groupId);
+
+    const { requesterId } = options;
+    if (!requesterId) {
+      throw new Error(
+        "groupService.leaveGroup: real 모드에서는 requesterId가 필요합니다.",
+      );
+    }
+
+    const result = await groupApi.leaveGroup({ groupId, requesterId });
+
+    if (result && typeof result === "object" && "success" in result) {
+      if (!result.success) {
+        throw new Error("그룹 탈퇴에 실패했습니다.");
+      }
+    }
+
+    return result;
   },
 
+  /**
+   * 그룹 생성
+   * payload 예시:
+   * {
+   *   requesterId: number,
+   *   title: string,
+   *   managerIds: number[],
+   *   memberIds: number[],
+   *   visibility: string,
+   *   description: string
+   * }
+   */
   async createGroup(payload) {
     if (USE_MOCK_GROUP) {
       return mockCreateGroup(payload);
     }
-    return groupApi.createGroup(payload);
+
+    const { requesterId, ...body } = payload || {};
+    if (!requesterId) {
+      throw new Error(
+        "groupService.createGroup: real 모드에서는 payload.requesterId가 필요합니다.",
+      );
+    }
+
+    const result = await groupApi.createGroup({ requesterId, ...body });
+
+    if (result && typeof result === "object" && "success" in result) {
+      if (!result.success) {
+        // 필요하다면 result.message 같은 필드를 읽어서 더 구체적인 에러로 던져도 됨
+        throw new Error("스터디 그룹 생성에 실패했습니다.");
+      }
+    }
+
+    return result;
   },
 
-  async fetchGroupById(groupId) {
+  /**
+   * 그룹 상세 조회
+   * - mock: 전체 정보
+   * - real: GET /api/v1/groups/{groupId}/detail
+   */
+  async fetchGroupById(groupId, options = {}) {
     if (USE_MOCK_GROUP) {
+      // mock에서는 requesterId 필요 없음
       return mockFetchGroupById(groupId);
     }
-    return groupApi.fetchGroupById(groupId);
+
+    const { requesterId } = options;
+    if (!requesterId) {
+      throw new Error(
+        "groupService.fetchGroupById: real 모드에서는 requesterId가 필요합니다.",
+      );
+    }
+
+    const apiGroup = await groupApi.fetchGroupById(groupId, { requesterId });
+    return mapGroupDetailFromApi(apiGroup);
   },
 
+  /**
+   * 그룹 수정
+   * payload 예시:
+   * {
+   *   requesterId: number,
+   *   title?: string,
+   *   visibility?: string,
+   *   description?: string,
+   *   managerIds?: number[],
+   *   memberIds?: number[],
+   * }
+   */
   async updateGroup(groupId, payload) {
     if (USE_MOCK_GROUP) {
       return mockUpdateGroup(groupId, payload);
     }
-    return groupApi.updateGroup(groupId, payload);
+
+    const { requesterId, ...body } = payload || {};
+    if (!requesterId) {
+      throw new Error(
+        "groupService.updateGroup: real 모드에서는 payload.requesterId가 필요합니다.",
+      );
+    }
+
+    const managerIds = uniqNums(body.managerIds);
+    const memberIds = uniqNums(body.memberIds).filter(
+      (id) => !managerIds.includes(id),
+    );
+
+    const result = await groupApi.updateGroup({
+      groupId,
+      requesterId,
+      title: body.title,
+      visibility: body.visibility,
+      description: body.description,
+      managerIds,
+      memberIds,
+    });
+
+    if (result && typeof result === "object" && "success" in result) {
+      if (!result.success) throw new Error("그룹 수정에 실패했습니다.");
+
+      const updated = await groupApi.fetchGroupById(groupId, { requesterId });
+      return mapGroupDetailFromApi(updated);
+    }
+
+    return result;
   },
 
+  /**
+   * 그룹 소유자 변경
+   * @param {{ requesterId: number, newOwnerId: number }} params
+   */
   async changeGroupOwner(groupId, { requesterId, newOwnerId }) {
     if (USE_MOCK_GROUP) {
       return mockChangeGroupOwner(groupId, { requesterId, newOwnerId });
     }
-    return groupApi.changeGroupOwner(groupId, { requesterId, newOwnerId });
+
+    if (!requesterId) {
+      throw new Error(
+        "groupService.changeGroupOwner: real 모드에서는 requesterId가 필요합니다.",
+      );
+    }
+
+    const result = await groupApi.changeGroupOwner({
+      groupId,
+      requesterId,
+      newOwnerId,
+    });
+
+    // Swagger 상 BasicResponse { success: boolean }
+    if (result && typeof result === "object" && "success" in result) {
+      if (!result.success) {
+        throw new Error("소유자 변경에 실패했습니다.");
+      }
+
+      const updated = await groupApi.fetchGroupById(groupId, { requesterId });
+      return mapGroupDetailFromApi(updated);
+    }
+
+    return result;
+  },
+
+  /**
+   * 그룹 사용자 목록 조회
+   * @param {number} groupId
+   * @param {{ requesterId: number }} options
+   * @return {Promise<Array<{id: number, name: string, nickname: string, role: string}>>}
+   */
+  async fetchGroupUsers(groupId, options = {}) {
+    if (USE_MOCK_GROUP) {
+      // TODO: mock은 fetchInitialMembers를 쓰도록 변경 필요
+      return [];
+    }
+
+    const { requesterId } = options;
+    if (!requesterId) {
+      throw new Error(
+        "groupService.fetchGroupUsers: requesterId가 필요합니다.",
+      );
+    }
+
+    const list = await groupApi.fetchGroupUsers(groupId, { requesterId });
+
+    return (list || []).map((u) => ({
+      id: Number(u.userId),
+      name: u.username,
+      nickname: u.username, // email 표시로 UI 개선 가능
+      role: u.role, // OWNER | MANAGER | MEMBER
+    }));
   },
 };


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/40
---
## ✅ 구현 내용

* **Group v1 스펙에 맞춰 requesterId 기반 계약을 프론트 전 구간에 관철**

  * Real API 호출 시 `requesterId`가 필수로 전달되도록 정리
  * `GET /groups/{groupId}/detail`, `PATCH`, `users` 등 v1 스펙에 맞는 호출 형태로 정렬
* **Service 레이어에 “API 응답 → FE 모델” 매핑 계층 도입**

  * 목록/상세 응답 필드(`title/name`, `managers/managerIds`, `members/memberIds`)를 FE에서 일관된 형태로 사용 가능하게 변환
  * Real 모드에서 requesterId 누락 시 조기 실패(throw)로 문제를 빠르게 드러내도록 변경
* **Store 레이어 옵션 확장 + mock/real 응답 차이를 안전하게 흡수**

  * `fetchGroups(options)`, `fetchGroupById(groupId, options)` 등 `options={ requesterId }` 지원
  * Real 모드에서 BasicResponse 형태 응답일 수 있어 state 업데이트를 “객체 반환 시에만” 반영하도록 가드 처리
* **Router Guard 권한 체크에서 group detail 조회 시 requesterId 전달**

  * 그룹 권한 검사 흐름에서 로그인 유저 id 기반으로 `fetchGroupById(groupId, { requesterId })` 호출

---

## 📂 변경 모듈

* `src/api/groupApi.*`

  * Group v1 spec 기반 엔드포인트/파라미터 정렬 (requesterId, detail, patch, users)
* `src/services/groupService.*`

  * requesterId 강제 + API→FE 매핑(`mapGroupDetailFromApi`) 도입
  * member/manager id 타입 정규화 유틸 추가
* `src/data/groupStore.*`

  * requesterId 옵션 전달 지원
  * mock/real 응답 형태 차이로 인한 state 업데이트 가드
* `src/router/index.*` (또는 router 파일)

  * 그룹 권한 체크 시 group detail fetch에 requesterId 전달

---

## 🧪 시나리오

* **그룹 목록 조회(Real)**

  * 로그인 유저(`requesterId`)가 있을 때만 API 호출 가능
  * requesterId 누락 시 즉시 에러로 실패(문제 조기 탐지)
* **그룹 상세 조회(Real)**

  * `fetchGroupById(groupId, { requesterId })`로 detail 조회
  * 응답을 FE 모델로 매핑하여 `ownerId/managerIds/memberIds`를 항상 숫자 배열로 확보
* **그룹 수정/소유자 변경(Real)**

  * BasicResponse(success) 형태면 성공 여부 검증 후 필요 시 detail 재조회로 최신 상태 확보
* **Router 권한 체크**

  * 그룹 멤버/매니저 페이지 진입 시 requesterId 포함된 상세 조회 기반으로 권한 판정

---

## 💡 기타

* **Breaking 가능성(의도된 계약 강화)**: Real 모드에서 requesterId 없는 호출은 더 이상 “조용히” 진행되지 않고 명시적으로 실패합니다.
* **후속 PR 가이드**

  * UI/컴포넌트 레이어에서는 `useAuthStore().user.id`를 기반으로 `fetch*` 호출에 `{ requesterId }`를 전달하는 패턴을 표준으로 사용하면 됩니다.
* **리뷰 포인트**

  * 매핑 기준(`title/name`, `members/memberIds`, `managers/managerIds`)이 백엔드 스펙과 정확히 맞는지
  * BasicResponse 처리 분기에서 state 업데이트 타이밍이 의도와 일치하는지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 그룹 사용자 조회 기능 추가

* **Bug Fixes**
  * 그룹 관련 경로에 대한 인증 강제 실행 개선
  * 그룹 데이터 업데이트 시 안정성 향상

* **Refactor**
  * 그룹 API 구조 개선: 일관된 매개변수 객체 기반 호출로 변경
  * 인증 및 권한 확인 로직 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->