### PR TITLE
[BSM-40] fix: propagate requesterId across group flows

### DIFF
--- a/src/components/group/GroupCreate.vue
+++ b/src/components/group/GroupCreate.vue
@@ -1,13 +1,17 @@
 <script setup>
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import { useRouter } from "vue-router";
 import GroupForm from "./GroupForm.vue";
 import { createGroup } from "../../data/groupStore";
+import { useAuthStore } from "../../data/authStore";
 
 const router = useRouter();
+const authStore = useAuthStore();
 
 const submitting = ref(false);
 const apiError = ref("");
+
+const currentUserId = computed(() => authStore.user.value?.id ?? null);
 
 async function handleSubmit(payload) {
   if (submitting.value) return;
@@ -16,10 +20,18 @@ async function handleSubmit(payload) {
   apiError.value = "";
 
   try {
-    // 실제로는 여기서 POST /api/v1/groups 호출
-    await createGroup(payload);
+    const uid = currentUserId.value;
+    if (!uid) {
+      apiError.value = "로그인 정보가 없어 스터디 그룹을 생성할 수 없습니다.";
+      return;
+    }
 
-    // 성공 시 그룹 리스트로 이동
+    await createGroup({
+      ...payload,
+      // managerIds: Array.from(new Set([currentUserId.value, ...payload.managerIds])),
+      requesterId: uid,
+    });
+
     router.push({ name: "GroupList" });
   } catch (e) {
     console.error(e);

--- a/src/components/group/GroupEdit.vue
+++ b/src/components/group/GroupEdit.vue
@@ -6,6 +6,7 @@ import {
   fetchGroupById,
   updateGroup,
   changeGroupOwner,
+  fetchGroupUsers,
 } from "../../data/groupStore";
 import { members, ensureMembersLoaded } from "../../data/memberStore";
 import { useAuthStore } from "../../data/authStore";
@@ -45,15 +46,26 @@ const currentUserId = computed(() => authStore.user.value?.id ?? null);
 
 const isCurrentUserOwner = computed(() => {
   if (!group.value || !currentUserId.value) return false;
-  return group.value.ownerId === currentUserId.value;
+  return Number(group.value.ownerId) === Number(currentUserId.value);
 });
 
 // 그룹 멤버 목록 (owner 후보들)
 const ownerCandidates = computed(() => {
   if (!group.value) return [];
-  const idSet = new Set([...(group.value.memberIds || [])]);
+
+  // ✅ ownerId + managerIds + memberIds 전부 포함
+  const idSet = new Set();
+
+  if (group.value.ownerId != null) {
+    idSet.add(Number(group.value.ownerId));
+  }
+
+  (group.value.managerIds || []).forEach((id) => idSet.add(Number(id)));
+
+  (group.value.memberIds || []).forEach((id) => idSet.add(Number(id)));
+
   // members는 전체 유저 모음에서 해당 ID만 필터
-  return members.value.filter((m) => idSet.has(m.id));
+  return members.value.filter((m) => idSet.has(Number(m.id)));
 });
 
 const currentOwner = computed(() => {
@@ -75,7 +87,20 @@ onMounted(async () => {
   try {
     await ensureMembersLoaded(1000);
 
-    const g = await fetchGroupById(groupId);
+    const uid = currentUserId.value;
+    if (!uid) {
+      throw new Error("로그인 정보가 없어 그룹 정보를 불러올 수 없습니다.");
+    }
+
+    const [g, groupUsers] = await Promise.all([
+      fetchGroupById(groupId, { requesterId: uid }),
+      fetchGroupUsers(groupId, { requesterId: uid }),
+    ]);
+
+    const byId = new Map(members.value.map((m) => [Number(m.id), m]));
+    groupUsers.forEach((u) => byId.set(Number(u.id), u));
+    members.value = Array.from(byId.values());
+
     group.value = g;
 
     // ⚠️ 기억용 주석:
@@ -104,8 +129,16 @@ async function handleSubmit(payload) {
   apiError.value = "";
 
   try {
-    // 실제로는 PUT /api/v1/groups/{groupId}
-    await updateGroup(groupId, payload);
+    const uid = currentUserId.value;
+    if (!uid) {
+      apiError.value = "로그인 정보가 없어 스터디 그룹을 수정할 수 없습니다.";
+      return;
+    }
+
+    await updateGroup(groupId, {
+      ...payload,
+      requesterId: uid,
+    });
 
     router.push({ name: "GroupList" });
   } catch (e) {
@@ -154,17 +187,17 @@ async function handleChangeOwner() {
       return;
     }
 
-    // 실제 백엔드라면:
-    // await httpClient.patch(
-    //   `/api/v1/groups/${groupId}/owner?requesterId=${requesterId}`,
-    //   ownerCandidateId.value
-    // );
     const updated = await changeGroupOwner(groupId, {
       requesterId,
       newOwnerId: ownerCandidateId.value,
     });
 
-    group.value = updated;
+    // mock 케이스에 한해 group.value 갱신
+    if (updated && typeof updated === "object" && "id" in updated) {
+      group.value = updated;
+      ownerCandidateId.value = updated.ownerId ?? ownerCandidateId.value;
+    }
+
     ownerChangeMessage.value = "소유자가 변경되었습니다.";
   } catch (e) {
     console.error(e);

--- a/src/components/group/GroupForm.vue
+++ b/src/components/group/GroupForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { searchMembers, members } from "../../data/memberStore";
 
 const props = defineProps({
@@ -59,21 +59,29 @@ function syncFromInitialGroup() {
   description.value = props.initialGroup.description || "";
   visibility.value = props.initialGroup.visibility || "PRIVATE";
 
-  // managerIds / memberIds 를 통해 selectedMembers 복원
-  const managerSet = new Set(props.initialGroup.managerIds || []);
-  const memberSet = new Set([
-    ...(props.initialGroup.memberIds || []),
-    ...managerSet,
-  ]);
+  const toNum = (v) => Number(v);
 
-  // memberStore 안에 있는 멤버 목록에서 찾아서 isManager 플래그 세팅
+  const managerSet = new Set((props.initialGroup.managerIds || []).map(toNum));
+  const memberSet = new Set(
+    [
+      ...(props.initialGroup.memberIds || []),
+      ...(props.initialGroup.managerIds || []),
+    ].map(toNum),
+  );
+
   selectedMembers.value = members.value
-    .filter((m) => memberSet.has(m.id))
+    .filter((m) => memberSet.has(toNum(m.id)))
     .map((m) => ({
       ...m,
-      isManager: managerSet.has(m.id),
+      isManager: managerSet.has(toNum(m.id)),
     }));
 }
+
+watch(
+  () => [props.initialGroup, members.value.length],
+  () => syncFromInitialGroup(),
+  { deep: true, immediate: true },
+);
 
 onMounted(() => {
   syncFromInitialGroup();
@@ -118,13 +126,21 @@ function toggleManager(userId) {
 const managerIds = computed(() =>
   selectedMembers.value.filter((m) => m.isManager).map((m) => m.id),
 );
-const memberIds = computed(() => selectedMembers.value.map((m) => m.id));
+const memberIds = computed(() =>
+  selectedMembers.value.filter((m) => !m.isManager).map((m) => m.id),
+);
+
+// 그룹 참여자 수 (관리자 + 멤버 중복 제거)
+const participantCount = computed(() => {
+  const set = new Set([...managerIds.value, ...memberIds.value]);
+  return set.size;
+});
 
 const canSubmit = computed(() => {
   return (
     title.value.trim().length > 0 &&
-    memberIds.value.length > 0 &&
-    managerIds.value.length > 0 && // 최소 1명은 관리자여야 함
+    participantCount.value > 0 && // 전체 참여자 1명 이상
+    managerIds.value.length > 0 && // 최소 1명은 관리자
     !props.submitting
   );
 });

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -86,7 +86,7 @@ async function handleLeaveGroup(groupId) {
     return;
   }
 
-  if (target?.ownerId === uid) {
+  if (Number(target?.ownerId) === Number(uid)) {
     window.alert(
       "이 그룹의 소유자는 바로 탈퇴할 수 없습니다.\n" +
         "그룹 수정 > 소유자 변경에서 소유권을 다른 멤버에게 넘긴 뒤 탈퇴해 주세요.",

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -19,6 +19,7 @@ onMounted(async () => {
     console.warn(
       "[GroupList] currentUserId가 없어 그룹 목록을 불러오지 않습니다.",
     );
+    window.alert("로그인이 필요합니다.");
     return;
   }
 

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -11,11 +11,19 @@ const leavingGroupId = ref(null);
 
 const searchQuery = ref("");
 
-onMounted(async () => {
-  await fetchGroups();
-});
-
 const currentUserId = computed(() => authStore.user.value?.id ?? null);
+
+onMounted(async () => {
+  const uid = currentUserId.value;
+  if (!uid) {
+    console.warn(
+      "[GroupList] currentUserId가 없어 그룹 목록을 불러오지 않습니다.",
+    );
+    return;
+  }
+
+  await fetchGroups({ requesterId: uid });
+});
 
 function hasId(list, uid) {
   if (!uid || !Array.isArray(list)) return false;
@@ -35,6 +43,13 @@ function isOwnerOrManager(group) {
 function isJoinedGroup(group) {
   const uid = currentUserId.value;
   if (!uid || !group) return false;
+
+  const hasMembershipArrays =
+    Array.isArray(group.managerIds) || Array.isArray(group.memberIds);
+
+  if (!hasMembershipArrays) {
+    return true;
+  }
 
   const isOwner = Number(group.ownerId) === Number(uid);
   const isManager = hasId(group.managerIds, uid);
@@ -64,8 +79,14 @@ function goEditGroup(groupId) {
 async function handleLeaveGroup(groupId) {
   const target = groups.value.find((g) => g.id === groupId);
   const name = target?.name ?? "이 그룹";
+  const uid = currentUserId.value;
 
-  if (currentUserId.value && target?.ownerId === currentUserId.value) {
+  if (!uid) {
+    window.alert("로그인 정보가 없어 그룹을 탈퇴할 수 없습니다.");
+    return;
+  }
+
+  if (target?.ownerId === uid) {
     window.alert(
       "이 그룹의 소유자는 바로 탈퇴할 수 없습니다.\n" +
         "그룹 수정 > 소유자 변경에서 소유권을 다른 멤버에게 넘긴 뒤 탈퇴해 주세요.",
@@ -81,7 +102,7 @@ async function handleLeaveGroup(groupId) {
 
   try {
     leavingGroupId.value = groupId;
-    await leaveGroup(groupId); // 실제로는 백엔드 API 호출 자리
+    await leaveGroup(groupId, { requesterId: uid });
   } catch (e) {
     console.error(e);
     alert("그룹 탈퇴 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -26,37 +26,14 @@ onMounted(async () => {
   await fetchGroups({ requesterId: uid });
 });
 
-function hasId(list, uid) {
-  if (!uid || !Array.isArray(list)) return false;
-  return list.some((id) => Number(id) === Number(uid));
-}
-
-function isOwnerOrManager(group) {
+/**
+ * Real API 그룹 목록 응답에는 managerIds/memberIds가 없어 멤버십 판별이 불가함. 목록 필터링(isJoinedGroup)을 제거함.
+ * TODO: 목록 응답에 myRole(OWNER/MANAGER/MEMBER) 또는 joined(boolean) 필드가 추가되면, GroupList에서 멤버십 기반 필터링/버튼 노출(매니저 수정권한 등)을 복구할 것.
+ */
+function isOwner(group) {
   const uid = currentUserId.value;
   if (!uid || !group) return false;
-
-  const isOwner = Number(group.ownerId) === Number(uid);
-  const isManager = hasId(group.managerIds, uid);
-
-  return isOwner || isManager;
-}
-
-function isJoinedGroup(group) {
-  const uid = currentUserId.value;
-  if (!uid || !group) return false;
-
-  const hasMembershipArrays =
-    Array.isArray(group.managerIds) || Array.isArray(group.memberIds);
-
-  if (!hasMembershipArrays) {
-    return true;
-  }
-
-  const isOwner = Number(group.ownerId) === Number(uid);
-  const isManager = hasId(group.managerIds, uid);
-  const isMember = hasId(group.memberIds, uid);
-
-  return isOwner || isManager || isMember;
+  return Number(group.ownerId) === Number(uid);
 }
 
 function goGroup(groupId) {
@@ -116,7 +93,7 @@ const filteredGroups = computed(() => {
   const q = searchQuery.value.trim().toLowerCase();
   const uid = currentUserId.value;
 
-  let list = groups.value.filter((g) => isJoinedGroup(g));
+  let list = [...groups.value];
 
   if (!uid) {
     list = [];
@@ -303,7 +280,7 @@ const filteredGroups = computed(() => {
 
               <!-- 그룹 수정 -->
               <button
-                v-if="isOwnerOrManager(group)"
+                v-if="isOwner(group)"
                 type="button"
                 class="px-3 py-1.5 text-xs font-medium border rounded-lg bg-white text-gray-700 hover:bg-gray-50"
                 @click.stop="goEditGroup(group.id)"

--- a/tests/GroupCreate.spec.js
+++ b/tests/GroupCreate.spec.js
@@ -1,6 +1,7 @@
 // tests/GroupCreate.spec.js
 import { mount, flushPromises } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
 
 // 1) vue-router mock
 vi.mock("vue-router", () => {
@@ -24,6 +25,16 @@ vi.mock("../src/data/groupStore", () => {
   return {
     __esModule: true,
     createGroup,
+  };
+});
+
+// 2.5) authStore mock 추가
+vi.mock("../src/data/authStore", () => {
+  const user = ref({ id: 1, name: "테스터", nickname: "tester" });
+  return {
+    __esModule: true,
+    useAuthStore: () => ({ user }),
+    user,
   };
 });
 
@@ -65,6 +76,7 @@ vi.mock("../src/components/group/GroupForm.vue", () => ({
 import GroupCreate from "../src/components/group/GroupCreate.vue";
 import { createGroup } from "../src/data/groupStore";
 import { router as routerMock } from "vue-router";
+import { user as authUser } from "../src/data/authStore";
 
 describe("GroupCreate.vue", () => {
   beforeEach(() => {
@@ -72,6 +84,8 @@ describe("GroupCreate.vue", () => {
     createGroup.mockReset();
     routerMock.push.mockReset();
     routerMock.back.mockReset();
+
+    authUser.value = { id: 1, name: "테스터", nickname: "tester" };
   });
 
   it("submit 이벤트를 받으면 createGroup 호출 후 GroupList로 이동한다", async () => {
@@ -85,17 +99,16 @@ describe("GroupCreate.vue", () => {
 
     // 1) createGroup 가 payload와 함께 호출되었는지
     expect(createGroup).toHaveBeenCalledTimes(1);
-    const payload = createGroup.mock.calls[0][0];
-    expect(payload).toEqual({
+    expect(createGroup).toHaveBeenCalledWith({
       title: "테스트 그룹",
       description: "설명",
       visibility: "PRIVATE",
       memberIds: [1],
       managerIds: [1],
+      requesterId: 1,
     });
 
     // 2) 성공 후 router.push({ name: 'GroupList' }) 호출 여부
-    expect(routerMock.push).toHaveBeenCalledTimes(1);
     expect(routerMock.push).toHaveBeenCalledWith({ name: "GroupList" });
   });
 

--- a/tests/GroupEdit.spec.js
+++ b/tests/GroupEdit.spec.js
@@ -59,12 +59,14 @@ vi.mock("../src/data/groupStore", () => {
   const fetchGroupById = vi.fn();
   const updateGroup = vi.fn();
   const changeGroupOwner = vi.fn();
+  const fetchGroupUsers = vi.fn();
 
   return {
     __esModule: true,
     fetchGroupById,
     updateGroup,
     changeGroupOwner,
+    fetchGroupUsers,
   };
 });
 
@@ -92,6 +94,7 @@ import {
   fetchGroupById,
   updateGroup,
   changeGroupOwner,
+  fetchGroupUsers,
 } from "../src/data/groupStore";
 import { user as authUser } from "../src/data/authStore";
 import { members as membersRef } from "../src/data/memberStore";
@@ -108,6 +111,8 @@ describe("GroupEdit.vue", () => {
     fetchGroupById.mockReset();
     updateGroup.mockReset();
     changeGroupOwner.mockReset();
+    fetchGroupUsers.mockReset();
+    fetchGroupUsers.mockResolvedValue([]);
     routerMock.push.mockReset();
     routerMock.back.mockReset();
   });
@@ -126,7 +131,8 @@ describe("GroupEdit.vue", () => {
     await flushPromises();
 
     expect(fetchGroupById).toHaveBeenCalledTimes(1);
-    expect(fetchGroupById).toHaveBeenCalledWith("1");
+    expect(fetchGroupById).toHaveBeenCalledWith("1", { requesterId: 1 });
+    expect(fetchGroupUsers).toHaveBeenCalledWith("1", { requesterId: 1 });
 
     expect(wrapper.text()).not.toContain("그룹 정보를 불러오는 중입니다...");
 
@@ -172,7 +178,6 @@ describe("GroupEdit.vue", () => {
       managerIds: [1],
       memberIds: [1, 2],
     });
-
     updateGroup.mockResolvedValue(true);
 
     const wrapper = mount(GroupEdit);
@@ -193,7 +198,10 @@ describe("GroupEdit.vue", () => {
     await flushPromises();
 
     expect(updateGroup).toHaveBeenCalledTimes(1);
-    expect(updateGroup).toHaveBeenCalledWith("1", payload);
+    expect(updateGroup).toHaveBeenCalledWith("1", {
+      ...payload,
+      requesterId: 1,
+    });
 
     expect(routerMock.push).toHaveBeenCalledTimes(1);
     expect(routerMock.push).toHaveBeenCalledWith({ name: "GroupList" });
@@ -208,7 +216,6 @@ describe("GroupEdit.vue", () => {
       managerIds: [1],
       memberIds: [1, 2],
     });
-
     updateGroup.mockRejectedValue(new Error("서버 오류"));
 
     const wrapper = mount(GroupEdit);
@@ -299,6 +306,10 @@ describe("GroupEdit.vue", () => {
       managerIds: [1],
       memberIds: [1, 2],
     });
+    fetchGroupUsers.mockResolvedValue([
+      { id: 1, name: "현재소유자", nickname: "owner", role: "OWNER" },
+      { id: 2, name: "새소유자", nickname: "newOwner", role: "MEMBER" },
+    ]);
 
     const wrapper = mount(GroupEdit);
     await flushPromises();

--- a/tests/GroupForm.spec.js
+++ b/tests/GroupForm.spec.js
@@ -335,7 +335,7 @@ describe("GroupForm.vue", () => {
     expect(payload.title).toBe("유효한 제목");
     expect(payload.description).toBe(""); // 설명은 입력 안 했으므로 trim() 결과 ""
     expect(payload.visibility).toBe("PRIVATE"); // 기본 값
-    expect(payload.memberIds).toEqual([2]);
+    expect(payload.memberIds).toEqual([]);
     expect(payload.managerIds).toEqual([2]);
   });
 

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -173,7 +173,7 @@ describe("GroupList.vue", () => {
     await nextTick();
 
     // owner 탈퇴 방어 로직에 걸리면 안 되므로, 정확히 id:3에 대해 호출됐는지만 체크
-    expect(leaveGroupMock).toHaveBeenCalledWith(3);
+    expect(leaveGroupMock).toHaveBeenCalledWith(3, { requesterId: 1 });
 
     confirmSpy.mockRestore();
     alertSpy.mockRestore();

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -85,16 +85,6 @@ describe("GroupList.vue", () => {
         memberCount: 3,
         updatedAt: "2025-01-03T12:00:00.000Z",
       },
-      {
-        id: 4,
-        name: "내가 속하지 않은 그룹",
-        description: "other",
-        ownerId: 999,
-        managerIds: [998],
-        memberIds: [997],
-        memberCount: 3,
-        updatedAt: "2025-01-04T12:00:00.000Z",
-      },
     ];
 
     fetchGroupsMock.mockReset();
@@ -109,6 +99,7 @@ describe("GroupList.vue", () => {
     await nextTick();
 
     expect(fetchGroupsMock).toHaveBeenCalledTimes(1);
+    expect(fetchGroupsMock).toHaveBeenCalledWith({ requesterId: 1 });
   });
 
   it("현재 로그인한 사용자가 속한 그룹(owner/manager/member)만 렌더링된다", async () => {
@@ -123,10 +114,10 @@ describe("GroupList.vue", () => {
     expect(text).toContain("내가 owner인 그룹");
     expect(text).toContain("내가 manager인 그룹");
     expect(text).toContain("내가 member만인 그룹");
-    expect(text).not.toContain("내가 속하지 않은 그룹");
   });
 
-  it("owner/manager 그룹에만 '수정' 버튼이 보이고, member-only 그룹에는 보이지 않는다", async () => {
+  // TODO: 요구사항 변경 시 manager도 수정 가능하도록 변경 필요
+  it("owner 그룹에만 '수정' 버튼이 보이고, member-only 그룹에는 보이지 않는다", async () => {
     const wrapper = mount(GroupList);
     await flushPromises();
     await nextTick();
@@ -147,7 +138,7 @@ describe("GroupList.vue", () => {
       item.findAll("button").some((btn) => btn.text().includes("수정"));
 
     expect(hasEdit(ownerItem)).toBe(true); // owner ⇒ 수정 버튼 있어야 함
-    expect(hasEdit(managerItem)).toBe(true); // manager ⇒ 수정 버튼 있어야 함
+    expect(hasEdit(managerItem)).toBe(false); // manager ⇒ 없어야 함
     expect(hasEdit(memberOnlyItem)).toBe(false); // 단순 member ⇒ 없어야 함
   });
 


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/40
---
## ✅ 구현 내용

* **Group 플로우 전반에서 `requesterId` 전파를 표준화**

  * GroupList / GroupCreate / GroupEdit 흐름에서 Real API 호출 시 `requesterId`가 빠지지 않도록 통일
  * 로그인 정보가 없는 경우, API 호출/액션을 **사전에 차단**하여 불필요한 요청 및 비정상 상태를 방지
* **GroupEdit에서 사용자 목록 로딩 경로 추가**

  * 소유자 변경/멤버 편집 등 편집 화면에서 필요한 유저 데이터를 `fetchGroupUsers`로 가져오는 흐름을 반영
* **GroupForm 초기 데이터 동기화 및 id 타입 정규화**

  * 스토어 로딩 타이밍(멤버 목록 로드)과 폼 초기값이 엇갈릴 때도 선택 상태가 깨지지 않도록 동기화
  * `id` 타입(string/number 혼재)로 인한 체크/선택 불일치를 방지하도록 정규화 처리

---

## 📂 변경 모듈

* `src/components/group/GroupList.vue` (또는 관련 컴포넌트)

  * 로그인 없을 때 액션 차단, requesterId 포함 호출 흐름 정리
* `src/components/group/GroupCreate.vue`

  * `createGroup` 호출 payload에 `requesterId` 포함
* `src/components/group/GroupEdit.vue`

  * `fetchGroupById(groupId, { requesterId })` 및 `fetchGroupUsers(groupId, { requesterId })` 연계
  * 소유자 변경 탭/후보 선택 흐름 보강
* `src/components/group/GroupForm.vue`

  * 초기 멤버/매니저 선택 상태 동기화
  * id 타입 정규화(숫자 기반 비교)
* `tests/*`

  * `test(group-list)`, `test(group-create)`, `test(group-edit)`, `test(group-form)` 전부 requesterId 계약에 맞게 업데이트

---

## 🧪 시나리오

* **GroupList**

  * 로그인 상태: `fetchGroups({ requesterId })`, `leaveGroup(groupId, { requesterId })` 정상 동작
  * 비로그인 상태: 목록 조회/탈퇴 등 액션이 호출되지 않도록 차단(UX/안정성)
* **GroupCreate**

  * submit 시 `createGroup({ ...payload, requesterId })`로 호출
  * 실패 시 기존 에러 메시지 유지 + 라우팅 이동 없음
* **GroupEdit**

  * 마운트 시 `fetchGroupById(groupId, { requesterId })` + `fetchGroupUsers(groupId, { requesterId })` 호출
  * submit 시 `updateGroup(groupId, { ...payload, requesterId })`
  * owner 변경 시 `changeGroupOwner(groupId, { requesterId, newOwnerId })`
* **GroupForm**

  * memberStore 로드 후에도 initialGroup 기반 선택 상태가 일관되게 유지
  * string/number 혼재 id여도 체크가 정상 동작

---

## 💡 기타

* **리뷰 포인트**

  * “로그인 없으면 막기” 정책이 GroupList/Create/Edit에서 동일하게 적용되는지
  * GroupForm의 id 정규화가 기존 데이터(backend/mock)와 충돌 없이 안전한지
* **테스트 유지보수성**

  * requesterId가 계약이 된 만큼, 향후 그룹 관련 API 확장도 동일 패턴으로 테스트가 자연스럽게 따라가도록 정리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 소유권·멤버 판별을 숫자 기준으로 일관화하여 검증 안정성 향상
  * 멤버 병합/동기화 시 중복 처리 보강

* **개선 사항**
  * 그룹 생성/편집/탈퇴에 인증(requesterId) 컨텍스트 적용 — 비로그인 시 명확한 오류 안내
  * 편집 버튼 노출을 소유자 기준으로 변경, 소유자 이탈 제한 보강
  * 제출 가능성 계산을 참여자(중복 제외) 기준으로 개선

* **테스트**
  * 인증 컨텍스트 및 사용자 목록 병합 시나리오 단위테스트 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->