### PR TITLE
[BSM-40] fix: use requesterId for group detail lookups

### DIFF
--- a/src/components/BoardList.vue
+++ b/src/components/BoardList.vue
@@ -17,7 +17,16 @@ const group = ref(null);
 onMounted(async () => {
   // 라우터 설정이 { path: '/groups/:groupId', ... } 라고 가정
   const groupId = route.params.groupId;
-  group.value = await fetchGroupById(groupId); // ownerId, managerIds 포함
+  const uid = currentUserId.value;
+
+  if (!uid) {
+    console.warn(
+      "[BoardList] currentUserId가 없어 그룹 정보를 불러오지 않습니다.",
+    );
+    return;
+  }
+
+  group.value = await fetchGroupById(groupId, { requesterId: uid });
   await fetchBoards(groupId);
 });
 

--- a/src/views/BoardDetailView.vue
+++ b/src/views/BoardDetailView.vue
@@ -151,8 +151,13 @@ onMounted(async () => {
     const gid = Number(route.params.groupId);
     const bid = Number(route.params.boardId);
 
+    const uid = currentUserId.value;
+    if (!uid) {
+      throw new Error("로그인 정보가 없어 보드 정보를 불러올 수 없습니다.");
+    }
+
     const [g, b, s] = await Promise.all([
-      fetchGroupById(gid),
+      fetchGroupById(gid, { requesterId: uid }),
       fetchBoardById(gid, bid),
       getBoardUserStatus({
         groupId: gid,

--- a/tests/BoardDetailView.spec.js
+++ b/tests/BoardDetailView.spec.js
@@ -145,7 +145,7 @@ describe("BoardDetailView.vue", () => {
     const wrapper = mount(BoardDetailView);
     await flushPromises();
 
-    expect(fetchGroupByIdMock).toHaveBeenCalledWith(1);
+    expect(fetchGroupByIdMock).toHaveBeenCalledWith(1, { requesterId: 1 });
     expect(fetchBoardByIdMock).toHaveBeenCalledWith(1, 10);
     expect(getBoardUserStatusMock).toHaveBeenCalledWith({
       groupId: 1,
@@ -258,22 +258,27 @@ describe("BoardDetailView.vue", () => {
     expect(headerText).not.toContain("집에갈까요");
   });
 
-  it("로그인하지 않은 경우 내 완료율 카드가 보이지 않고 '내 현황만 보기' 체크박스가 비활성화된다", async () => {
-    // user 를 null 로 변경
+  it("로그인하지 않은 경우 에러 메시지를 렌더링하고 API를 호출하지 않는다", async () => {
     const auth = useAuthStoreMock();
     auth.user.value = null;
 
-    setupSuccessMocks();
+    setupSuccessMocks(); // 호출되면 안 되지만, 있어도 무관
 
     const wrapper = mount(BoardDetailView);
     await flushPromises();
 
-    // 내 완료율 카드가 없음
-    expect(wrapper.text()).not.toContain("내 완료율");
+    // 현재 구현: 로그인 없으면 catch로 빠져 에러 화면 렌더링
+    expect(wrapper.text()).toContain(
+      "보드 정보를 불러오는 중 오류가 발생했습니다.",
+    );
 
-    // 체크박스 disabled
-    const checkbox = wrapper.get("input[type='checkbox']");
-    expect(checkbox.attributes("disabled")).toBeDefined();
+    // 로그인 없으면 API 호출 자체가 없어야 정상
+    expect(fetchGroupByIdMock).not.toHaveBeenCalled();
+    expect(fetchBoardByIdMock).not.toHaveBeenCalled();
+    expect(getBoardUserStatusMock).not.toHaveBeenCalled();
+
+    // 체크박스 영역 자체가 렌더링되지 않음 (error 분기)
+    expect(wrapper.find("input[type='checkbox']").exists()).toBe(false);
   });
 
   it("상단 '보드 목록으로' 버튼 클릭 시 BoardList 라우트로 이동한다", async () => {

--- a/tests/BoardList.spec.js
+++ b/tests/BoardList.spec.js
@@ -119,7 +119,7 @@ describe("BoardList.vue", () => {
     mount(BoardList);
     await flushPromises();
 
-    expect(fetchGroupByIdMock).toHaveBeenCalledWith(1);
+    expect(fetchGroupByIdMock).toHaveBeenCalledWith(1, { requesterId: 1 });
     expect(fetchBoardsMock).toHaveBeenCalledWith(1);
   });
 


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/40
---
## ✅ 구현 내용

* **BoardList / BoardDetail에서 그룹 상세 조회 시 `requesterId`를 함께 전달**하도록 수정했습니다.

  * Real API에서 그룹 상세 조회가 `requesterId`를 요구하는 스펙에 맞춰, 화면 진입 시 권한/멤버십 판단에 필요한 데이터를 안정적으로 조회합니다.
* **BoardDetail은 로그인 없이 진입 시 데이터 로딩을 차단**하도록 방어 로직을 추가했습니다.

  * 로그인 정보가 없으면 API 호출을 수행하지 않고 에러 상태로 전환해, 불필요한 요청/권한 오류를 예방합니다.

---

## 📂 변경 모듈

* `components/BoardList.vue` (또는 해당 화면에서 group detail 호출하는 컴포넌트)

  * `fetchGroupById(groupId, { requesterId })` 형태로 호출 변경
* `views/BoardDetailView.vue`

  * 로그인 없는 경우 early return + group detail 조회에 requesterId 포함
* `tests/*`

  * BoardList/BoardDetail 관련 테스트에서 `fetchGroupById` 호출 시그니처 변경을 반영

---

## 🧪 시나리오

* [x] **로그인 상태로 BoardList 진입**

  * 그룹 상세 조회가 `fetchGroupById(groupId, { requesterId })`로 호출됨
* [x] **로그인 상태로 BoardDetail 진입**

  * 보드/상태 조회는 정상 동작
  * 그룹 상세 조회는 requesterId 포함하여 정상 동작
* [x] **비로그인 상태로 BoardDetail 진입**

  * API 호출이 발생하지 않음
  * 에러 메시지가 렌더링되어 사용자에게 상태가 명확히 전달됨
* [x] 테스트에서 위 동작을 모두 검증하도록 expectation 업데이트

---

## 💡 기타

* Real API 스펙이 `requesterId` 기반으로 권한/멤버십 정보를 판단하는 구조라, **Board 화면에서도 동일한 호출 규약을 강제**했습니다.
* 이 PR은 Board 영역에서의 requesterId 누락으로 발생하던 **권한 체크 실패/데이터 로딩 실패 가능성**을 제거하는 목적입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 로그인하지 않은 사용자가 보드 정보를 불러올 때 오류 메시지 표시
  * 데이터 로드 전 사용자 인증 확인 강화

* **테스트**
  * API 호출 인증 검증 테스트 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->