### PR TITLE
[BSM-54] feat: use groupRole permissions (manager can edit) 

### DIFF
--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -259,10 +259,17 @@ const filteredGroups = computed(() => {
               </span>
 
               <span
-                v-if="currentUserId && group.ownerId === currentUserId"
+                v-if="isOwner(group)"
                 class="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-800 border border-yellow-200"
               >
                 ⭐ 내 소유 그룹
+              </span>
+
+              <span
+                v-if="isManager(group)"
+                class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700 border border-blue-100"
+              >
+                🛠 매니저
               </span>
             </div>
 

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -37,7 +37,18 @@ function isOwner(group) {
 }
 
 function isManager(group) {
-  return !!group && group.groupRole === "MANAGER";
+  if (!group) return false;
+
+  if (group.groupRole) return group.groupRole === "MANAGER";
+
+  const uid = currentUserId.value;
+  if (!uid) return false;
+  const mids = Array.isArray(group.managerIds)
+    ? group.managerIds.map(Number)
+    : [];
+
+  if (isOwner(group)) return false;
+  return mids.includes(Number(uid));
 }
 
 function canEditGroup(group) {
@@ -266,7 +277,7 @@ const filteredGroups = computed(() => {
               </span>
 
               <span
-                v-if="isManager(group)"
+                v-else-if="isManager(group)"
                 class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700 border border-blue-100"
               >
                 🛠 매니저

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -26,14 +26,22 @@ onMounted(async () => {
   await fetchGroups({ requesterId: uid });
 });
 
-/**
- * Real API 그룹 목록 응답에는 managerIds/memberIds가 없어 멤버십 판별이 불가함. 목록 필터링(isJoinedGroup)을 제거함.
- * TODO: 목록 응답에 myRole(OWNER/MANAGER/MEMBER) 또는 joined(boolean) 필드가 추가되면, GroupList에서 멤버십 기반 필터링/버튼 노출(매니저 수정권한 등)을 복구할 것.
- */
 function isOwner(group) {
+  if (!group) return false;
+  if (group.groupRole) return group.groupRole === "OWNER";
+
   const uid = currentUserId.value;
-  if (!uid || !group) return false;
+  if (!uid) return false;
+
   return Number(group.ownerId) === Number(uid);
+}
+
+function isManager(group) {
+  return !!group && group.groupRole === "MANAGER";
+}
+
+function canEditGroup(group) {
+  return isOwner(group) || isManager(group);
 }
 
 function goGroup(groupId) {
@@ -64,7 +72,7 @@ async function handleLeaveGroup(groupId) {
     return;
   }
 
-  if (Number(target?.ownerId) === Number(uid)) {
+  if (isOwner(target)) {
     window.alert(
       "이 그룹의 소유자는 바로 탈퇴할 수 없습니다.\n" +
         "그룹 수정 > 소유자 변경에서 소유권을 다른 멤버에게 넘긴 뒤 탈퇴해 주세요.",
@@ -280,7 +288,7 @@ const filteredGroups = computed(() => {
 
               <!-- 그룹 수정 -->
               <button
-                v-if="isOwner(group)"
+                v-if="canEditGroup(group)"
                 type="button"
                 class="px-3 py-1.5 text-xs font-medium border rounded-lg bg-white text-gray-700 hover:bg-gray-50"
                 @click.stop="goEditGroup(group.id)"

--- a/src/services/groupService.js
+++ b/src/services/groupService.js
@@ -57,6 +57,7 @@ export const groupService = {
       ownerId: g.ownerId,
       visibility: g.visibility,
       memberCount: g.memberCount,
+      groupRole: g.groupRole ?? null,
       createdAt: g.createdAt,
       updatedAt: g.updatedAt,
       description: g.description ?? "",

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -51,6 +51,14 @@ function findGroupItemByName(wrapper, groupName) {
   return items.find((li) => li.text().includes(groupName));
 }
 
+function hasButton(item, label) {
+  return item.findAll("button").some((btn) => btn.text().includes(label));
+}
+
+function findButton(item, label) {
+  return item.findAll("button").find((btn) => btn.text().includes(label));
+}
+
 describe("GroupList.vue", () => {
   beforeEach(() => {
     // 유저(1)가 owner / manager / member 인 그룹 + 완전 관계없는 그룹
@@ -60,8 +68,7 @@ describe("GroupList.vue", () => {
         name: "내가 owner인 그룹",
         description: "owner",
         ownerId: 1,
-        managerIds: [],
-        memberIds: [2, 3],
+        groupRole: "OWNER",
         memberCount: 3,
         updatedAt: "2025-01-01T12:00:00.000Z",
       },
@@ -70,8 +77,7 @@ describe("GroupList.vue", () => {
         name: "내가 manager인 그룹",
         description: "manager",
         ownerId: 2,
-        managerIds: [1],
-        memberIds: [2, 3],
+        groupRole: "MANAGER",
         memberCount: 3,
         updatedAt: "2025-01-02T12:00:00.000Z",
       },
@@ -80,8 +86,7 @@ describe("GroupList.vue", () => {
         name: "내가 member만인 그룹",
         description: "member only",
         ownerId: 3,
-        managerIds: [3],
-        memberIds: [1, 4, 5],
+        groupRole: "MEMBER",
         memberCount: 3,
         updatedAt: "2025-01-03T12:00:00.000Z",
       },
@@ -116,33 +121,73 @@ describe("GroupList.vue", () => {
     expect(text).toContain("내가 member만인 그룹");
   });
 
-  // TODO: 요구사항 변경 시 manager도 수정 가능하도록 변경 필요
-  it("owner 그룹에만 '수정' 버튼이 보이고, member-only 그룹에는 보이지 않는다", async () => {
+  it("OWNER/MANAGER 그룹에는 '수정' 버튼이 보이고, MEMBER 그룹에는 보이지 않는다 (groupRole 기준)", async () => {
     const wrapper = mount(GroupList);
     await flushPromises();
     await nextTick();
 
     const ownerItem = findGroupItemByName(wrapper, "내가 owner인 그룹");
     const managerItem = findGroupItemByName(wrapper, "내가 manager인 그룹");
-    const memberOnlyItem = findGroupItemByName(wrapper, "내가 member만인 그룹");
+    const memberItem = findGroupItemByName(wrapper, "내가 member만인 그룹");
 
-    // 방어적으로 먼저 존재 확인
     expect(ownerItem, "owner 그룹 li를 찾지 못했습니다").toBeTruthy();
     expect(managerItem, "manager 그룹 li를 찾지 못했습니다").toBeTruthy();
-    expect(
-      memberOnlyItem,
-      "member-only 그룹 li를 찾지 못했습니다",
-    ).toBeTruthy();
+    expect(memberItem, "member 그룹 li를 찾지 못했습니다").toBeTruthy();
 
-    const hasEdit = (item) =>
-      item.findAll("button").some((btn) => btn.text().includes("수정"));
-
-    expect(hasEdit(ownerItem)).toBe(true); // owner ⇒ 수정 버튼 있어야 함
-    expect(hasEdit(managerItem)).toBe(false); // manager ⇒ 없어야 함
-    expect(hasEdit(memberOnlyItem)).toBe(false); // 단순 member ⇒ 없어야 함
+    expect(hasButton(ownerItem, "수정")).toBe(true);
+    expect(hasButton(managerItem, "수정")).toBe(true);
+    expect(hasButton(memberItem, "수정")).toBe(false);
   });
 
-  it("member-only 그룹에서 '그룹 탈퇴' 클릭 시 leaveGroup이 호출된다", async () => {
+  it("MANAGER가 '수정' 클릭 시 GroupEdit로 이동한다", async () => {
+    const wrapper = mount(GroupList);
+    await flushPromises();
+    await nextTick();
+
+    const managerItem = findGroupItemByName(wrapper, "내가 manager인 그룹");
+    expect(managerItem).toBeTruthy();
+
+    const editBtn = findButton(managerItem, "수정");
+    expect(editBtn, "'수정' 버튼을 찾지 못했습니다").toBeTruthy();
+
+    await editBtn.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    expect(pushMock).toHaveBeenCalledWith({
+      name: "GroupEdit",
+      params: { groupId: 2 },
+    });
+  });
+
+  it("OWNER는 '그룹 탈퇴' 클릭 시 차단되고 leaveGroup이 호출되지 않는다", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm");
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+    const wrapper = mount(GroupList);
+    await flushPromises();
+    await nextTick();
+
+    const ownerItem = findGroupItemByName(wrapper, "내가 owner인 그룹");
+    expect(ownerItem).toBeTruthy();
+
+    const leaveBtn = findButton(ownerItem, "그룹 탈퇴");
+    expect(leaveBtn, "'그룹 탈퇴' 버튼을 찾지 못했습니다").toBeTruthy();
+
+    await leaveBtn.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    expect(alertSpy).toHaveBeenCalled(); // 차단 안내
+    expect(confirmSpy).not.toHaveBeenCalled(); // confirm까지 가지 않음
+    expect(leaveGroupMock).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  it("MEMBER 그룹에서 '그룹 탈퇴' 클릭 시 leaveGroup이 호출된다", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
 
@@ -150,20 +195,16 @@ describe("GroupList.vue", () => {
     await flushPromises();
     await nextTick();
 
-    const memberOnlyItem = findGroupItemByName(wrapper, "내가 member만인 그룹");
-    expect(memberOnlyItem).toBeTruthy();
+    const memberItem = findGroupItemByName(wrapper, "내가 member만인 그룹");
+    expect(memberItem).toBeTruthy();
 
-    const leaveButton = memberOnlyItem
-      .findAll("button")
-      .find((btn) => btn.text().includes("그룹 탈퇴"));
+    const leaveBtn = findButton(memberItem, "그룹 탈퇴");
+    expect(leaveBtn, "'그룹 탈퇴' 버튼을 찾지 못했습니다").toBeTruthy();
 
-    expect(leaveButton, "'그룹 탈퇴' 버튼을 찾지 못했습니다").toBeTruthy();
-
-    await leaveButton.trigger("click");
+    await leaveBtn.trigger("click");
     await flushPromises();
     await nextTick();
 
-    // owner 탈퇴 방어 로직에 걸리면 안 되므로, 정확히 id:3에 대해 호출됐는지만 체크
     expect(leaveGroupMock).toHaveBeenCalledWith(3, { requesterId: 1 });
 
     confirmSpy.mockRestore();


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/54
---

## ✅ 구현 내용

* **그룹 목록 응답의 `groupRole`을 FE 모델에 매핑**하여, 목록 단계에서 내 권한(OWNER/MANAGER/MEMBER)을 알 수 있도록 반영했습니다.
* **GroupList 권한 판단을 `groupRole` 기반으로 개선**했습니다.

  * `isOwner`: `groupRole`이 있으면 이를 우선 사용, 없으면 `ownerId === currentUserId`로 fallback
  * `isManager`: `groupRole === "MANAGER"`
  * `canEditGroup`: OWNER 또는 MANAGER면 수정 가능
* **매니저도 그룹 수정 가능**하도록 “수정” 버튼 노출 조건을 `canEditGroup(group)`로 변경했습니다.
* 그룹 카드에 **매니저 뱃지**를 추가하고, “내 소유 그룹” 뱃지 노출 조건도 `isOwner(group)`로 통일했습니다.

---

## 📂 변경 모듈

* `tests/GroupList.spec.js` (groupRole 기준으로 테스트 시나리오 업데이트/추가)
* `src/services/groupService.js` (`fetchGroups`에서 `groupRole` 매핑)
* `src/components/group/GroupList.vue`

  * 권한 유틸(`isOwner / isManager / canEditGroup`) 추가 및 버튼/로직 반영
  * 매니저 뱃지 표시

---

## 🧪 시나리오

* [x] 마운트 시 `fetchGroups({ requesterId })` 호출된다
* [x] **OWNER/MANAGER** 그룹에는 “수정” 버튼이 보이고, **MEMBER** 그룹에는 보이지 않는다 (groupRole 기준)
* [x] **MANAGER**가 “수정” 클릭 시 `GroupEdit`로 이동한다
* [x] **OWNER**는 “그룹 탈퇴” 클릭 시 차단되고 `leaveGroup`이 호출되지 않는다
* [x] **MEMBER**는 “그룹 탈퇴” 클릭 시 confirm 후 `leaveGroup(groupId, { requesterId })`가 호출된다

---

## 💡 기타

* `groupRole`이 아직 내려오지 않는(또는 null) 케이스를 고려해 `isOwner`는 `ownerId` 비교로 fallback 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹에 매니저 역할이 추가되고 UI에 매니저 상태(매니저 표시)가 도입되었습니다.

* **개선 사항**
  * 권한 확인이 역할(OWNER/MANAGER/MEMBER) 기반으로 개선되어 소유자·매니저에 따른 버튼·배지 표시가 일관되게 동작합니다.
  * 소유자 탈퇴 동작이 차단되도록 UI 흐름이 보강되었습니다.

* **테스트**
  * 역할 기반 표시와 편집·탈퇴 동작을 검증하는 테스트가 추가·갱신되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->