### PR TITLE
[BSM-56] feat: allow owner-only group creation (relax member/manager validation)

### DIFF
--- a/src/components/group/GroupForm.vue
+++ b/src/components/group/GroupForm.vue
@@ -130,25 +130,14 @@ const memberIds = computed(() =>
   selectedMembers.value.filter((m) => !m.isManager).map((m) => m.id),
 );
 
-// 그룹 참여자 수 (관리자 + 멤버 중복 제거)
-const participantCount = computed(() => {
-  const set = new Set([...managerIds.value, ...memberIds.value]);
-  return set.size;
-});
-
 const canSubmit = computed(() => {
-  return (
-    title.value.trim().length > 0 &&
-    participantCount.value > 0 && // 전체 참여자 1명 이상
-    managerIds.value.length > 0 && // 최소 1명은 관리자
-    !props.submitting
-  );
+  return title.value.trim().length > 0 && !props.submitting;
 });
 
 // ----- submit / cancel -----
 async function handleSubmit() {
   if (!canSubmit.value) {
-    formError.value = "그룹 이름과 멤버/관리자를 설정했는지 확인해주세요.";
+    formError.value = "그룹 이름을 입력했는지 확인해주세요.";
     return;
   }
 
@@ -373,8 +362,8 @@ function handleCancel() {
         </div>
 
         <p class="text-[11px] text-gray-400 mt-1">
-          최소 1명 이상을 <span class="font-semibold">관리자</span>로 지정해야
-          그룹을 만들 수 있어요.
+          멤버/관리자 추가는 선택사항이에요. 그룹 생성자는 자동으로
+          <span class="font-semibold">owner</span>로 포함됩니다.
         </p>
       </div>
 

--- a/tests/GroupForm.spec.js
+++ b/tests/GroupForm.spec.js
@@ -277,12 +277,7 @@ describe("GroupForm.vue", () => {
     expect(emits.length).toBe(1);
   });
 
-  it("유효성 검사: 제목/멤버/관리자가 설정되지 않으면 제출 버튼이 비활성화되고, 조건 충족 시 활성화 + 올바른 payload로 submit emit", async () => {
-    // 검색 결과 mock
-    searchMembers.mockResolvedValue([
-      { id: 2, name: "이알고", nickname: "algoLee" },
-    ]);
-
+  it("유효성 검사: 제목만 입력하면(선택 멤버 0명) 제출이 가능하고, 빈 managerIds/memberIds로 submit emit 한다", async () => {
     const wrapper = mount(GroupForm, {
       props: { mode: "create", submitting: false },
     });
@@ -293,40 +288,15 @@ describe("GroupForm.vue", () => {
     // 초기: disabled
     expect(submitButton.attributes("disabled")).toBeDefined();
 
-    // 1. 제목만 입력
+    // 1. 제목 입력 -> 이제 바로 활성화되어야 함
     await wrapper
       .find('input[placeholder="예) 청강산 1기 알고리즘 캠프"]')
       .setValue("유효한 제목");
     await wrapper.vm.$nextTick();
-    expect(submitButton.attributes("disabled")).toBeDefined();
 
-    // 2. 멤버 검색 & 선택 (하지만 아직 관리자로 지정하지 않음)
-    await wrapper
-      .find('input[placeholder="이름 또는 닉네임으로 검색"]')
-      .setValue("이알고");
-    const searchButton = findButtonByText(wrapper, "검색");
-    await searchButton.trigger("click");
-    await flushPromises();
-
-    const searchBox = wrapper.findAll("div.border.rounded-xl")[0];
-    const resultItem = searchBox.find("li");
-    await resultItem.trigger("click"); // 선택됨 (isManager=false)
-    await wrapper.vm.$nextTick();
-
-    // 여전히 disabled (관리자 없음)
-    expect(submitButton.attributes("disabled")).toBeDefined();
-
-    // 3. 선택된 멤버를 관리자 지정
-    const selectedBox = wrapper.findAll("div.border.rounded-xl")[1];
-    const selectedItem = selectedBox.find("li");
-    const managerBtn = findButtonByText(selectedItem, "관리자로 지정");
-    await managerBtn.trigger("click");
-    await wrapper.vm.$nextTick();
-
-    // 이제 버튼 활성화
     expect(submitButton.attributes("disabled")).toBeUndefined();
 
-    // 4. 제출 버튼 클릭 → submit 이벤트 payload 검증
+    // 2. 제출 버튼 클릭 → submit 이벤트 payload 검증
     await submitButton.trigger("click");
     const emits = wrapper.emitted("submit");
     expect(emits).toBeTruthy();
@@ -336,7 +306,7 @@ describe("GroupForm.vue", () => {
     expect(payload.description).toBe(""); // 설명은 입력 안 했으므로 trim() 결과 ""
     expect(payload.visibility).toBe("PRIVATE"); // 기본 값
     expect(payload.memberIds).toEqual([]);
-    expect(payload.managerIds).toEqual([2]);
+    expect(payload.managerIds).toEqual([]);
   });
 
   it("mode='edit' 일 때 버튼 텍스트가 '변경 사항 저장'으로 표시된다", async () => {


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/56
---
✅ 구현 내용
- 그룹 생성/수정 시 제출 조건에서 아래 정책을 제거했습니다.
  - 관리자 1명 이상 필수
  - 멤버(참여자) 1명 이상 필수
- 이제 그룹 이름만 입력하면 owner 단독으로도 그룹 생성이 가능합니다.
- 안내 문구 및 유효성 에러 메시지를 변경된 정책에 맞게 수정했습니다.

📂 변경 모듈
- src/components/group/GroupForm.vue
- tests/GroupForm.spec.js

🧪 시나리오
1) 그룹 생성 화면에서 제목이 비어있으면 제출 버튼이 비활성화된다
2) 제목만 입력하면(선택된 멤버 0명) 제출 버튼이 활성화된다
3) 제출 시 emit payload에서 managerIds/memberIds가 빈 배열이어도 정상 전달된다
4) (기존 기능) 멤버 검색/선택/관리자 토글/삭제 동작은 그대로 유지된다

💡 기타
- owner는 백엔드에서 생성자 기준으로 자동 포함되며,
  managerIds/memberIds에는 포함되지 않는 정책을 유지합니다.
- 따라서 UI에서 선택된 멤버가 0명이어도 owner 1명 그룹이 성립합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 그룹 생성 프로세스를 단순화했습니다. 이제 그룹 제목만 필수로 요구됩니다.
  * 구성원 및 관리자 추가는 선택사항으로 변경되었습니다.
  * 그룹 생성자는 자동으로 소유자로 포함됩니다.
  * 오류 메시지를 간소화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->