### PR TITLE
[BSM-39] feat: validate signup nickname/boj and enhance password recovery tests

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -53,13 +53,21 @@ export async function loginWithIdPw({ email, password }) {
 }
 
 /**
- * 회원가입 (ID/PW 기반)
+ * 회원가입
+ * POST /api/v1/auth/register
+ * RegisterRequest: { email, username, password, baekjoon }
  */
-export async function signupWithIdPw({ email, nickname, password }) {
-  const response = await httpClient.post("/auth/signup", {
+export async function signupWithIdPw({
+  email,
+  nickname,
+  password,
+  baekjoonId,
+}) {
+  const response = await httpClient.post("/auth/register", {
     email,
-    nickname,
+    username: nickname,
     password,
+    baekjoon: baekjoonId ?? null,
   });
 
   return response.data;
@@ -67,32 +75,30 @@ export async function signupWithIdPw({ email, nickname, password }) {
 
 /**
  * 닉네임(username) 중복 확인
- * GET /api/v1/auth/duplicate/username?username=홍길동
- * -> baseURL이 /api 이므로 여기서는 /v1/... 로 호출
+ * GET /api/v1/auth/duplicate/username?username=...
  */
 export async function checkUsernameDuplicate({ username }) {
-  const response = await httpClient.get("/v1/auth/duplicate/username", {
+  const response = await httpClient.get("/auth/duplicate/username", {
     params: { username },
   });
 
-  // 백엔드 응답 예시(가정):
-  // { duplicated: true } 또는 { available: false } 등
-  return response.data;
+  return response.data; // { duplicated: boolean }
 }
 
 /**
- * 백엔드에서 Baekjoon 프로필 존재 여부 확인
- * GET /api/v1/baekjoon/verify?handle=xxx
+ * solved.ac 백준 핸들 존재 여부 확인
+ * GET /api/v1/auth/existHandle?handle=...
+ * 응답: boolean
  */
 export async function verifyBaekjoonId({ handle }) {
-  const response = await httpClient.get("/v1/baekjoon/verify", {
+  const response = await httpClient.get("/auth/existHandle", {
     params: { handle },
   });
 
-  // 예시 응답: { exists: true }
-  return response.data;
+  return response.data; // boolean
 }
 
+// TODO: after mypage api integration
 /**
  * 내 계정에 연결된 Baekjoon 아이디 저장/수정
  * PATCH /api/v1/members/me/baekjoon-id
@@ -118,14 +124,19 @@ export async function logout() {
     clearAccessToken();
   }
 }
+
 /**
- * 비밀번호 재설정 메일 발송
+ * 비밀번호 재설정 메일/임시 비밀번호 발급
+ * POST /api/v1/auth/password/reset
+ * body: { email }
+ * res: BaseResponse { success, message }
  */
 export async function forgotPassword({ email }) {
-  const response = await httpClient.post("/auth/forgot-password", { email });
+  const response = await httpClient.post("/auth/password/reset", { email });
   return response.data;
 }
 
+// TODO: after email verification api changes
 /**
  * 비밀번호 재설정
  */
@@ -136,34 +147,3 @@ export async function resetPassword({ token, newPassword }) {
   });
   return response.data;
 }
-
-/**
- * 2) 나중에 JWT로 전환할 때 쓸 예시 (현재는 주석으로만 보관)
- *
- * JWT 적용 시, httpClient에 accessToken을 실어 보내고,
- * refreshToken은 httpOnly 쿠키나 별도 저장 전략을 사용.
- *
- * // import httpClient, { setAccessToken, clearAccessToken } from "./httpClient";
- *
- * export async function loginWithJwt({ id, password }) {
- *   const response = await httpClient.post("/auth/login", { id, password });
- *   const { accessToken, refreshToken, user } = response.data;
- *
- *   setAccessToken(accessToken);
- *   // refreshToken은 브라우저 저장소(localStorage)보다는 httpOnly 쿠키 권장
- *
- *   return { accessToken, refreshToken, user };
- * }
- *
- * export async function refreshAccessToken() {
- *   const response = await httpClient.post("/auth/refresh");
- *   const { accessToken } = response.data;
- *   setAccessToken(accessToken);
- *   return accessToken;
- * }
- *
- * export async function logoutJwt() {
- *   await httpClient.post("/auth/logout");
- *   clearAccessToken();
- * }
- */

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -81,31 +81,21 @@ export const authService = {
    * 회원가입
    */
   async signup({ email, nickname, password, baekjoonId }) {
-    if (USE_MOCK_AUTH) {
+    if (USE_MOCK_AUTH)
       return mockSignup({ email, nickname, password, baekjoonId });
-    }
 
-    const data = await signupWithIdPw({
-      email,
-      nickname,
-      password,
-      baekjoonId,
-    });
-
-    return data;
+    return signupWithIdPw({ email, nickname, password, baekjoonId });
   },
 
   /**
    * 비밀번호 재설정 메일 발송
    */
   async forgotPassword({ email }) {
-    if (USE_MOCK_AUTH) {
-      return mockForgotPassword({ email });
-    }
-
-    return forgotPasswordApi({ email });
+    if (USE_MOCK_AUTH) return mockForgotPassword({ email });
+    return forgotPasswordApi({ email }); // BaseResponse
   },
 
+  // TODO: after email verification api changes
   /**
    * 비밀번호 재설정
    */
@@ -117,6 +107,7 @@ export const authService = {
     return resetPasswordApi({ token, newPassword });
   },
 
+  // TODO: after mypage api integration
   /**
    * 비밀번호 재확인 (본인 인증)
    * - mock: 비밀번호 검증 + 최신 user 반환
@@ -132,6 +123,7 @@ export const authService = {
     );
   },
 
+  // TODO: after mypage api integration
   /**
    * 비밀번호 변경
    */
@@ -149,24 +141,21 @@ export const authService = {
    * 닉네임(=username) 중복 확인
    */
   async checkUsernameDuplicate({ username }) {
-    if (USE_MOCK_AUTH) {
-      return mockCheckUsernameDuplicate({ username });
-    }
-
-    return checkUsernameDuplicateApi({ username });
+    if (USE_MOCK_AUTH) return mockCheckUsernameDuplicate({ username });
+    return checkUsernameDuplicateApi({ username }); // { duplicated }
   },
 
   /**
    * 백준 아이디 존재 여부 확인
    */
   async checkBaekjoonId({ handle }) {
-    if (USE_MOCK_AUTH) {
-      return mockCheckBaekjoonId({ handle });
-    }
+    if (USE_MOCK_AUTH) return mockCheckBaekjoonId({ handle });
 
-    return verifyBaekjoonIdApi({ handle });
+    const res = await verifyBaekjoonIdApi({ handle }); // boolean
+    return { exists: !!res };
   },
 
+  // TODO: after mypage api integration
   /**
    * 닉네임 변경
    */
@@ -181,6 +170,7 @@ export const authService = {
     );
   },
 
+  // TODO: after mypage api integration
   /**
    * 백준 아이디 변경
    */
@@ -192,6 +182,7 @@ export const authService = {
     return updateBaekjoonIdApi({ baekjoonId });
   },
 
+  // TODO: after mypage api integration
   /**
    * 회원 탈퇴
    */

--- a/src/views/SignupView.vue
+++ b/src/views/SignupView.vue
@@ -102,7 +102,7 @@ async function handleCheckBaekjoonId() {
 
   try {
     const res = await authService.checkBaekjoonId({ handle });
-    // 가정: { exists: boolean }
+
     if (res.exists) {
       isBaekjoonValid.value = true;
       baekjoonCheckMessage.value = "존재하는 백준 아이디입니다.";
@@ -146,6 +146,11 @@ function validate() {
 
   if (password.value !== passwordConfirm.value) {
     errorMessage.value = "비밀번호와 비밀번호 확인이 일치하지 않습니다.";
+    return false;
+  }
+
+  if (isNicknameDuplicated.value === null) {
+    errorMessage.value = "닉네임 중복 확인을 해주세요.";
     return false;
   }
 

--- a/tests/ForgotPasswordView.spec.js
+++ b/tests/ForgotPasswordView.spec.js
@@ -81,4 +81,22 @@ describe("ForgotPasswordView", () => {
       query: { token: "reset-token-456" },
     });
   });
+
+  it("token이 없는 응답이면 개발용 바로가기 버튼이 렌더링되지 않는다", async () => {
+    authService.forgotPassword.mockResolvedValue({
+      success: true,
+      message: "OK",
+    });
+
+    const wrapper = mount(ForgotPasswordView);
+
+    await wrapper.find("#forgot-email").setValue("user@example.com");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "입력하신 이메일로 비밀번호 재설정 안내를 보냈습니다. (이메일이 등록되어 있다면)",
+    );
+    expect(wrapper.text()).not.toContain("새 비밀번호 설정하러 가기");
+  });
 });

--- a/tests/SignupView.spec.js
+++ b/tests/SignupView.spec.js
@@ -147,6 +147,9 @@ describe("SignupView", () => {
       exists: true,
     });
 
+    const nickSpy = authService.checkUsernameDuplicate;
+    nickSpy.mockResolvedValue({ duplicated: false, available: true });
+
     const wrapper = mount(SignupView);
     await goToFormStep(wrapper);
 
@@ -160,6 +163,13 @@ describe("SignupView", () => {
       .find((btn) => btn.text().includes("아이디 확인"));
     expect(bjCheckBtn).toBeTruthy();
     await bjCheckBtn.trigger("click");
+    await flushPromises();
+
+    // 닉네임 중복 확인
+    const nicknameCheckBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("중복 확인"));
+    await nicknameCheckBtn.trigger("click");
     await flushPromises();
 
     await wrapper.find("#signup-password").setValue("password123");
@@ -296,5 +306,87 @@ describe("SignupView", () => {
     expect(wrapper.text()).toContain(
       "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.",
     );
+  });
+
+  it("닉네임 변경 시 중복 상태/메시지가 초기화된다", async () => {
+    authService.checkUsernameDuplicate.mockResolvedValue({ duplicated: true });
+
+    const wrapper = mount(SignupView);
+    await goToFormStep(wrapper);
+
+    await wrapper.find("#nickname").setValue("dupUser");
+
+    const nicknameCheckButton = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("중복 확인"));
+    await nicknameCheckButton.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.",
+    );
+
+    // 닉네임 바꾸면 메시지 사라져야 함
+    await wrapper.find("#nickname").setValue("newUser");
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain(
+      "이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.",
+    );
+  });
+
+  it("백준 아이디 변경 시 검증 상태/메시지가 초기화된다", async () => {
+    authService.checkBaekjoonId.mockResolvedValue({ exists: false });
+
+    const wrapper = mount(SignupView);
+    await goToFormStep(wrapper);
+
+    await wrapper.find("#baekjoon-id").setValue("no_such_user");
+
+    const bjCheckBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("아이디 확인"));
+    await bjCheckBtn.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      "존재하지 않는 백준 아이디입니다. 다시 확인해주세요.",
+    );
+
+    // 변경하면 메시지 사라져야 함
+    await wrapper.find("#baekjoon-id").setValue("tourist");
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain(
+      "존재하지 않는 백준 아이디입니다. 다시 확인해주세요.",
+    );
+  });
+
+  it("닉네임 중복 확인을 하지 않으면 제출 시 에러를 보여준다", async () => {
+    authService.checkBaekjoonId.mockResolvedValue({ exists: true });
+
+    const wrapper = mount(SignupView);
+    await goToFormStep(wrapper);
+
+    await wrapper.find("#signup-email").setValue("user@example.com");
+    await wrapper.find("#baekjoon-id").setValue("tourist");
+    await wrapper.find("#nickname").setValue("user");
+
+    // 백준 확인만 하고
+    const bjCheckBtn = wrapper
+      .findAll("button")
+      .find((btn) => btn.text().includes("아이디 확인"));
+    await bjCheckBtn.trigger("click");
+    await flushPromises();
+
+    await wrapper.find("#signup-password").setValue("password123");
+    await wrapper.find("#signup-password-confirm").setValue("password123");
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    // 구현 정책에 맞는 메시지로 assert
+    expect(wrapper.text()).toContain("닉네임 중복 확인을 해주세요.");
+    expect(authService.signup).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
이슈 번호 : https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/39
---

## ✅ 구현 내용

* **회원가입(Signup)**

  * 백준 아이디 존재 여부 확인 버튼 플로우 유지 (`checkBaekjoonId`)
  * **닉네임 중복 확인을 “필수”로 강화**

    * 중복 확인을 하지 않은 상태(`isNicknameDuplicated === null`)에서 제출 시 에러 처리
    * 중복 상태(`isNicknameDuplicated === true`) 제출 차단
* **비밀번호 찾기(ForgotPassword)**

  * `forgotPassword` 호출 후 안내 메시지 노출
  * 개발 편의용 token 응답이 있을 때만 “바로가기(ResetPassword 이동)” UI 노출 (mock 대응)
  * token 없는 응답(BaseResponse 형태)에서도 정상 동작하도록 케이스 커버

---

## 📂 변경 모듈

* `src/views/SignupView.vue`

  * validate 로직 강화(닉네임 중복 확인 필수 정책 반영)
* `src/views/ForgotPasswordView.vue`

  * token 유무에 따른 UI 분기 유지/정리
* `tests/SignupView.spec.js`

  * 닉네임 중복 확인 필수 정책 반영하여 “성공 시나리오”에 중복 확인 단계 추가
  * 닉네임 미확인 제출 차단 시나리오 추가/보강
* `tests/ForgotPasswordView.spec.js`

  * token 없는 응답 시 “개발용 바로가기” 미노출 시나리오 추가
---

## 🧪 시나리오

### SignupView

* [x] 약관 2개 필수 체크 후 폼 단계로 이동
* [x] 필수 필드 누락 시 검증 메시지 노출
* [x] 백준 아이디 미입력 시 “백준 아이디를 입력해주세요.” 노출
* [x] 백준 아이디 확인을 누르지 않으면 제출 차단
* [x] 비밀번호/확인 불일치 시 제출 차단
* [x] 닉네임 중복 확인을 하지 않으면 제출 차단 (**정책 변경 포인트**)
* [x] 닉네임 중복(true)인 경우 제출 차단
* [x] 백준 확인 + 닉네임 중복 확인(false) 완료 시 signup 호출 → Login 라우팅

### ForgotPasswordView

* [x] 이메일 미입력 시 검증 메시지 노출
* [x] 정상 이메일 입력 시 forgotPassword 호출 및 안내 메시지 노출
* [x] 응답에 token 존재 시 “새 비밀번호 설정하러 가기” 버튼 렌더링 및 클릭 시 ResetPassword 이동
* [x] token 없는 응답(BaseResponse) 시 개발용 버튼이 렌더링되지 않음

---

## 💡 기타

* **정책 변경 주의:** “닉네임 중복 확인”이 이제 가입 필수 조건이므로, 관련 테스트/UX가 이에 맞춰 동작합니다.
* 필요 시, 닉네임 중복 확인 UX(버튼 클릭 강제/자동 확인/디바운스 등)는 후속 개선 사항으로 분리 가능합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 검증 및 변경 기능 추가
  * 별명 업데이트 기능 추가
  * 백준 아이디 관리 기능 추가
  * 계정 삭제 기능 추가

* **버그 수정**
  * 회원가입 시 닉네임 중복 확인 필수 검증 추가

* **테스트**
  * 회원가입 및 비밀번호 찾기 기능의 테스트 커버리지 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->