### PR TITLE
[BSM-60] feat: align profile settings with updated users API

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -147,3 +147,18 @@ export async function resetPassword({ token, newPassword }) {
   });
   return response.data;
 }
+
+/**
+ * 비밀번호 재확인(재인증)
+ * POST /api/v1/auth/password/verify
+ * body: { userId, password }
+ * res: boolean
+ */
+export async function verifyPassword({ userId, password }) {
+  const response = await httpClient.post("/auth/password/verify", {
+    userId,
+    password,
+  });
+
+  return response.data; // boolean
+}

--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -1,0 +1,52 @@
+import httpClient from "./httpClient";
+
+/**
+ * 유저 정보 조회
+ * GET /api/v1/users/{id}
+ * res:
+ * {
+ *   userId: number,
+ *   email: string,
+ *   username: string,
+ *   baekjoonHandle: string | null,
+ *   status: "ACTIVE" | ...,
+ *   createdAt: string,
+ *   updatedAt: string
+ * }
+ */
+export async function fetchUserInfo({ id }) {
+  const res = await httpClient.get(`/users/${id}`);
+  return res.data;
+}
+
+/**
+ * 닉네임 변경
+ * PATCH /api/v1/users/{id}/username
+ * body: { username }
+ * res: BaseResponse
+ */
+export async function changeUsername({ id, username }) {
+  const res = await httpClient.patch(`/users/${id}/username`, { username });
+  return res.data;
+}
+
+/**
+ * 비밀번호 변경
+ * PATCH /api/v1/users/{id}/password
+ * body: { password }
+ * res: BaseResponse
+ */
+export async function changePassword({ id, password }) {
+  const res = await httpClient.patch(`/users/${id}/password`, { password });
+  return res.data;
+}
+
+/**
+ * 회원 탈퇴
+ * DELETE /api/v1/users/{id}
+ * res: BaseResponse
+ */
+export async function deleteUser({ id }) {
+  const res = await httpClient.delete(`/users/${id}`);
+  return res.data;
+}

--- a/src/data/authStore.js
+++ b/src/data/authStore.js
@@ -17,6 +17,11 @@ function clearUser() {
   state.user = null;
 }
 
+function updateUser(patch) {
+  if (!state.user) return;
+  state.user = { ...state.user, ...patch };
+}
+
 /**
  * 로그인
  * @param {{ email: string, password: string }} credentials
@@ -102,5 +107,7 @@ export function useAuthStore() {
     fetchCurrentUser,
     logout,
     resetError,
+
+    updateUser,
   };
 }

--- a/src/mocks/auth.mock.js
+++ b/src/mocks/auth.mock.js
@@ -344,7 +344,7 @@ export async function mockVerifyPassword({ userId, password }) {
   }
 
   const users = loadUsers();
-  const user = users.find((u) => u.id === current.id);
+  const user = users.find((u) => u.id === targetId);
 
   if (!user || user.password !== password) {
     const error = new Error("비밀번호가 올바르지 않습니다.");

--- a/src/mocks/auth.mock.js
+++ b/src/mocks/auth.mock.js
@@ -7,12 +7,42 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/**
+ * 로컬스토리지에 예전 스키마가 남아 있어도 깨지지 않도록
+ * 저장/조회 시 내부 표준 형태로 정규화
+ *
+ * 내부 표준:
+ * { id, email, nickname, password, baekjoonId, status, createdAt, updatedAt }
+ */
+function normalizeUser(u) {
+  const id = u?.id ?? u?.userId ?? Date.now();
+  const createdAt = u?.createdAt ?? nowIso();
+  const updatedAt = u?.updatedAt ?? createdAt;
+
+  return {
+    id,
+    email: u?.email ?? "",
+    nickname: u?.nickname ?? u?.username ?? "",
+    password: u?.password ?? "",
+    // 과거 baekjoonId / 최신 baekjoonHandle 모두 수용
+    baekjoonId: u?.baekjoonId ?? u?.baekjoonHandle ?? u?.baekjoon ?? "",
+    status: u?.status ?? "ACTIVE",
+    createdAt,
+    updatedAt,
+  };
+}
+
 function loadUsers() {
   if (typeof window === "undefined") return [];
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY_USERS);
     if (!raw) return [];
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map(normalizeUser) : [];
   } catch (e) {
     console.error("Failed to parse users from localStorage", e);
     return [];
@@ -21,7 +51,11 @@ function loadUsers() {
 
 function saveUsers(users) {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(STORAGE_KEY_USERS, JSON.stringify(users));
+  // 저장도 normalize하여 스키마 통일
+  window.localStorage.setItem(
+    STORAGE_KEY_USERS,
+    JSON.stringify((users ?? []).map(normalizeUser)),
+  );
 }
 
 function loadResetTokens() {
@@ -108,12 +142,17 @@ export async function mockSignup({ email, nickname, password, baekjoonId }) {
     throw error;
   }
 
+  const createdAt = nowIso();
+
   const newUser = {
     id: Date.now(),
     email,
     nickname,
     password, // ⚠️ 실제 프로덕션에서는 평문 저장 금지 (BCrypt 등 사용)
-    baekjoonId,
+    baekjoonId: baekjoonId ?? "",
+    status: "ACTIVE",
+    createdAt,
+    updatedAt: createdAt,
   };
 
   const nextUsers = [...users, newUser];
@@ -164,6 +203,7 @@ export async function mockLogin({ email, password }) {
         id: user.id,
         email: user.email,
         nickname: user.nickname,
+        baekjoonId: user.baekjoonId ?? "",
       }),
     );
 
@@ -177,6 +217,7 @@ export async function mockLogin({ email, password }) {
       id: user.id,
       email: user.email,
       nickname: user.nickname,
+      baekjoonId: user.baekjoonId ?? "",
     },
     // JWT 도입 시 함께 반환:
     // accessToken,
@@ -189,7 +230,13 @@ export function mockGetCurrentUser() {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY_CURRENT_USER);
     if (!raw) return null;
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    return {
+      id: parsed?.id ?? parsed?.userId ?? null,
+      email: parsed?.email ?? "",
+      nickname: parsed?.nickname ?? parsed?.username ?? "",
+      baekjoonId: parsed?.baekjoonId ?? parsed?.baekjoonHandle ?? "",
+    };
   } catch (e) {
     console.error("Failed to parse currentUser from localStorage", e);
     return null;
@@ -271,6 +318,7 @@ export async function mockResetPassword({ token, newPassword }) {
   }
 
   users[idx].password = newPassword; // ⚠️ 목이라 그냥 저장
+  users[idx].updatedAt = nowIso();
   saveUsers(users);
 
   // 해당 토큰은 한 번만 사용 가능하도록 제거
@@ -283,11 +331,13 @@ export async function mockResetPassword({ token, newPassword }) {
   return { ok: true };
 }
 
-export async function mockVerifyPassword({ password }) {
+export async function mockVerifyPassword({ userId, password }) {
   await delay(300);
 
   const current = mockGetCurrentUser();
-  if (!current) {
+  const targetId = userId ?? current?.id;
+
+  if (!targetId) {
     const error = new Error("로그인 상태가 아닙니다.");
     error.code = "NOT_LOGGED_IN";
     throw error;
@@ -302,19 +352,43 @@ export async function mockVerifyPassword({ password }) {
     throw error;
   }
 
-  // 비밀번호까지 맞으면, 최신 프로필 리턴
+  return true;
+}
+
+export async function mockFetchUserInfo({ id }) {
+  await delay(200);
+
+  const current = mockGetCurrentUser();
+  const targetId = id ?? current?.id;
+
+  if (!targetId) {
+    const error = new Error("로그인 상태가 아닙니다.");
+    error.code = "NOT_LOGGED_IN";
+    throw error;
+  }
+
+  const users = loadUsers();
+  const user = users.find((u) => u.id === targetId);
+
+  if (!user) {
+    const error = new Error("사용자를 찾을 수 없습니다.");
+    error.code = "USER_NOT_FOUND";
+    throw error;
+  }
+
   return {
-    user: {
-      id: user.id,
-      email: user.email,
-      nickname: user.nickname,
-      baekjoonId: user.baekjoonId,
-    },
+    userId: user.id,
+    email: user.email,
+    username: user.nickname,
+    baekjoonHandle: user.baekjoonId || null,
+    status: user.status ?? "ACTIVE",
+    createdAt: user.createdAt,
+    updatedAt: user.updatedAt ?? user.createdAt,
   };
 }
 
 // ===== 닉네임 변경 =====
-export async function mockUpdateNickname({ nickname }) {
+export async function mockUpdateNickname(payload) {
   await delay(400);
 
   const current = mockGetCurrentUser();
@@ -324,8 +398,11 @@ export async function mockUpdateNickname({ nickname }) {
     throw error;
   }
 
+  const nickname = payload?.nickname ?? payload?.username ?? "";
+  const targetId = payload?.id ?? payload?.userId ?? current.id;
+
   const users = loadUsers();
-  const idx = users.findIndex((u) => u.id === current.id);
+  const idx = users.findIndex((u) => u.id === targetId);
 
   if (idx === -1) {
     const error = new Error("사용자를 찾을 수 없습니다.");
@@ -334,9 +411,10 @@ export async function mockUpdateNickname({ nickname }) {
   }
 
   users[idx].nickname = nickname;
+  users[idx].updatedAt = nowIso();
   saveUsers(users);
 
-  // currentUser 캐시도 최신 닉네임으로 업데이트
+  // currentUser 캐시도 업데이트
   if (typeof window !== "undefined") {
     window.localStorage.setItem(
       STORAGE_KEY_CURRENT_USER,
@@ -344,6 +422,7 @@ export async function mockUpdateNickname({ nickname }) {
         id: users[idx].id,
         email: users[idx].email,
         nickname: users[idx].nickname,
+        baekjoonId: users[idx].baekjoonId ?? "",
       }),
     );
   }
@@ -353,57 +432,13 @@ export async function mockUpdateNickname({ nickname }) {
       id: users[idx].id,
       email: users[idx].email,
       nickname: users[idx].nickname,
-    },
-  };
-}
-
-export async function mockUpdateBaekjoonId({ baekjoonId }) {
-  await delay(400);
-
-  const current = mockGetCurrentUser();
-  if (!current) {
-    const error = new Error("로그인 상태가 아닙니다.");
-    error.code = "NOT_LOGGED_IN";
-    throw error;
-  }
-
-  const users = loadUsers();
-  const idx = users.findIndex((u) => u.id === current.id);
-
-  if (idx === -1) {
-    const error = new Error("사용자를 찾을 수 없습니다.");
-    error.code = "USER_NOT_FOUND";
-    throw error;
-  }
-
-  users[idx].baekjoonId = baekjoonId;
-  saveUsers(users);
-
-  // currentUser 캐시도 최신 백준 아이디로 업데이트
-  if (typeof window !== "undefined") {
-    window.localStorage.setItem(
-      STORAGE_KEY_CURRENT_USER,
-      JSON.stringify({
-        id: users[idx].id,
-        email: users[idx].email,
-        nickname: users[idx].nickname,
-        baekjoonId: users[idx].baekjoonId,
-      }),
-    );
-  }
-
-  return {
-    user: {
-      id: users[idx].id,
-      email: users[idx].email,
-      nickname: users[idx].nickname,
-      baekjoonId: users[idx].baekjoonId,
+      baekjoonId: users[idx].baekjoonId ?? "",
     },
   };
 }
 
 // ===== 비밀번호 변경 =====
-export async function mockChangePassword({ newPassword }) {
+export async function mockChangePassword(payload) {
   await delay(400);
 
   const current = mockGetCurrentUser();
@@ -413,8 +448,11 @@ export async function mockChangePassword({ newPassword }) {
     throw error;
   }
 
+  const newPassword = payload?.newPassword ?? payload?.password ?? "";
+  const targetId = payload?.id ?? payload?.userId ?? current.id;
+
   const users = loadUsers();
-  const idx = users.findIndex((u) => u.id === current.id);
+  const idx = users.findIndex((u) => u.id === targetId);
 
   if (idx === -1) {
     const error = new Error("사용자를 찾을 수 없습니다.");
@@ -423,6 +461,7 @@ export async function mockChangePassword({ newPassword }) {
   }
 
   users[idx].password = newPassword;
+  users[idx].updatedAt = nowIso();
   saveUsers(users);
 
   // 비밀번호 바꾸면 보통 세션/로그인을 끊는 편이라,
@@ -431,7 +470,7 @@ export async function mockChangePassword({ newPassword }) {
 }
 
 // ===== 회원 탈퇴 =====
-export async function mockDeleteAccount() {
+export async function mockDeleteAccount(payload = {}) {
   await delay(400);
 
   const current = mockGetCurrentUser();
@@ -441,8 +480,10 @@ export async function mockDeleteAccount() {
     throw error;
   }
 
+  const targetId = payload?.id ?? payload?.userId ?? current.id;
+
   const users = loadUsers();
-  const nextUsers = users.filter((u) => u.id !== current.id);
+  const nextUsers = users.filter((u) => u.id !== targetId);
   saveUsers(nextUsers);
 
   // 로그인 정보/토큰 정리
@@ -450,36 +491,3 @@ export async function mockDeleteAccount() {
 
   return { ok: true };
 }
-
-/**
- * ===== 실제 백엔드 전환 시 예시 =====
- *
- * // authApi.js
- * export async function verifyPassword({ password }) {
- *   return httpClient.post("/auth/verify-password", { password });
- * }
- *
- * export async function changePassword({ newPassword }) {
- *   return httpClient.post("/auth/change-password", { newPassword });
- * }
- *
- * // memberApi.js
- * export async function updateMyProfile({ nickname }) {
- *   return httpClient.patch("/members/me", { nickname });
- * }
- *
- * export async function deleteMyAccount() {
- *   return httpClient.delete("/members/me");
- * }
- */
-
-/**
- * ===== 나중에 JWT로 전환할 때 예시 =====
- *
- * // 로그인 시
- * // const { user, accessToken, refreshToken } = await mockLogin({ email, password });
- * // window.localStorage.setItem(STORAGE_KEY_ACCESS_TOKEN, accessToken);
- *
- * // httpClient 인터셉터에서 ACCESS_TOKEN을 Authorization 헤더로 붙이고,
- * // refreshToken은 httpOnly 쿠키 or 별도 저장전략 사용.
- */

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -25,6 +25,7 @@ import {
   mockForgotPassword,
   mockResetPassword,
   mockVerifyPassword,
+  mockFetchUserInfo,
   mockUpdateNickname,
   mockChangePassword,
   mockDeleteAccount,
@@ -126,14 +127,12 @@ export const authService = {
     return resetPasswordApi({ token, newPassword });
   },
 
-  // TODO: after mypage api integration
   /**
    * 비밀번호 재확인 (본인 인증)
    */
   async verifyPassword({ userId, password }) {
     if (USE_MOCK_AUTH) {
-      const res = await mockVerifyPassword({ password, userId });
-      return !!res?.ok;
+      return mockVerifyPassword({ userId, password });
     }
 
     return verifyPasswordApi({ userId, password }); // boolean
@@ -144,14 +143,8 @@ export const authService = {
    */
   async getUserInfo({ id }) {
     if (USE_MOCK_AUTH) {
-      const me = mockGetCurrentUser();
-      if (!me) return null;
-      return {
-        id: me.id,
-        email: me.email,
-        nickname: me.nickname,
-        baekjoonId: me.baekjoonId ?? "",
-      };
+      const u = await mockFetchUserInfo({ id });
+      return toFrontendUser(u);
     }
 
     const u = await fetchUserInfo({ id }); // { userId, username, baekjoonHandle, ... }
@@ -162,7 +155,7 @@ export const authService = {
    * 비밀번호 변경
    */
   async changePassword({ id, newPassword }) {
-    if (USE_MOCK_AUTH) return mockChangePassword({ newPassword });
+    if (USE_MOCK_AUTH) return mockChangePassword({ id, newPassword });
 
     return changePasswordApi({ id, password: newPassword });
   },
@@ -189,7 +182,7 @@ export const authService = {
    * 닉네임 변경
    */
   async updateNickname({ id, nickname }) {
-    if (USE_MOCK_AUTH) return mockUpdateNickname({ nickname });
+    if (USE_MOCK_AUTH) return mockUpdateNickname({ id, nickname });
 
     await changeUsername({ id, username: nickname });
     const u = await fetchUserInfo({ id });
@@ -200,7 +193,7 @@ export const authService = {
    * 회원 탈퇴
    */
   async deleteAccount({ id }) {
-    if (USE_MOCK_AUTH) return mockDeleteAccount();
+    if (USE_MOCK_AUTH) return mockDeleteAccount({ id });
     return deleteUser({ id });
   },
 };

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -7,8 +7,16 @@ import {
   resetPassword as resetPasswordApi,
   checkUsernameDuplicate as checkUsernameDuplicateApi,
   verifyBaekjoonId as verifyBaekjoonIdApi,
-  updateBaekjoonId as updateBaekjoonIdApi,
+  verifyPassword as verifyPasswordApi,
 } from "@/api/authApi";
+
+import {
+  fetchUserInfo,
+  changeUsername,
+  changePassword as changePasswordApi,
+  deleteUser,
+} from "@/api/userApi";
+
 import {
   mockLogin,
   mockLogout,
@@ -22,10 +30,21 @@ import {
   mockDeleteAccount,
   mockCheckUsernameDuplicate,
   mockCheckBaekjoonId,
-  mockUpdateBaekjoonId,
 } from "@/mocks/auth.mock";
 
 const USE_MOCK_AUTH = apiMode.auth === "mock";
+
+function toFrontendUser(u) {
+  return {
+    id: u.userId,
+    email: u.email,
+    nickname: u.username,
+    baekjoonId: u.baekjoonHandle ?? "",
+    status: u.status,
+    createdAt: u.createdAt,
+    updatedAt: u.updatedAt,
+  };
+}
 
 export const authService = {
   /**
@@ -110,31 +129,42 @@ export const authService = {
   // TODO: after mypage api integration
   /**
    * 비밀번호 재확인 (본인 인증)
-   * - mock: 비밀번호 검증 + 최신 user 반환
-   * - real: TODO(/auth/verify-password 준비 시 연동)
    */
-  async verifyPassword({ password }) {
+  async verifyPassword({ userId, password }) {
     if (USE_MOCK_AUTH) {
-      return mockVerifyPassword({ password });
+      const res = await mockVerifyPassword({ password, userId });
+      return !!res?.ok;
     }
 
-    throw new Error(
-      "authService.verifyPassword: not implemented for real API yet",
-    );
+    return verifyPasswordApi({ userId, password }); // boolean
   },
 
-  // TODO: after mypage api integration
+  /**
+   * (MyPage) 유저 조회
+   */
+  async getUserInfo({ id }) {
+    if (USE_MOCK_AUTH) {
+      const me = mockGetCurrentUser();
+      if (!me) return null;
+      return {
+        id: me.id,
+        email: me.email,
+        nickname: me.nickname,
+        baekjoonId: me.baekjoonId ?? "",
+      };
+    }
+
+    const u = await fetchUserInfo({ id }); // { userId, username, baekjoonHandle, ... }
+    return toFrontendUser(u);
+  },
+
   /**
    * 비밀번호 변경
    */
-  async changePassword({ newPassword }) {
-    if (USE_MOCK_AUTH) {
-      return mockChangePassword({ newPassword });
-    }
+  async changePassword({ id, newPassword }) {
+    if (USE_MOCK_AUTH) return mockChangePassword({ newPassword });
 
-    throw new Error(
-      "authService.changePassword: not implemented for real API yet",
-    );
+    return changePasswordApi({ id, password: newPassword });
   },
 
   /**
@@ -155,45 +185,22 @@ export const authService = {
     return { exists: !!res };
   },
 
-  // TODO: after mypage api integration
   /**
    * 닉네임 변경
    */
-  async updateNickname({ nickname }) {
-    if (USE_MOCK_AUTH) {
-      return mockUpdateNickname({ nickname });
-    }
+  async updateNickname({ id, nickname }) {
+    if (USE_MOCK_AUTH) return mockUpdateNickname({ nickname });
 
-    // TODO: memberApi.updateMyProfile({ nickname })로 연동
-    throw new Error(
-      "authService.updateNickname: not implemented for real API yet",
-    );
+    await changeUsername({ id, username: nickname });
+    const u = await fetchUserInfo({ id });
+    return { user: toFrontendUser(u) };
   },
 
-  // TODO: after mypage api integration
-  /**
-   * 백준 아이디 변경
-   */
-  async updateBaekjoonId({ baekjoonId }) {
-    if (USE_MOCK_AUTH) {
-      return mockUpdateBaekjoonId({ baekjoonId });
-    }
-
-    return updateBaekjoonIdApi({ baekjoonId });
-  },
-
-  // TODO: after mypage api integration
   /**
    * 회원 탈퇴
    */
-  async deleteAccount() {
-    if (USE_MOCK_AUTH) {
-      return mockDeleteAccount();
-    }
-
-    // TODO: memberApi.deleteMyAccount()로 연동
-    throw new Error(
-      "authService.deleteAccount: not implemented for real API yet",
-    );
+  async deleteAccount({ id }) {
+    if (USE_MOCK_AUTH) return mockDeleteAccount();
+    return deleteUser({ id });
   },
 };

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -22,14 +22,6 @@ const email = ref("");
 const nickname = ref("");
 const originalNickname = ref("");
 const baekjoonId = ref("");
-// const originalBaekjoonId = ref("");
-
-// 백준 아이디 수정 상태
-// const isEditingBaekjoonId = ref(false);
-// const isSavingBaekjoonId = ref(false);
-// const isCheckingBaekjoonId = ref(false);
-// const baekjoonCheckMessage = ref("");
-// const isBaekjoonValid = ref(null); // null: 모름, true: 존재, false: 없음
 
 // 닉네임 수정 상태
 const isEditingNickname = ref(false);
@@ -44,13 +36,6 @@ watch(nickname, () => {
   isNicknameDuplicated.value = null;
   nicknameCheckMessage.value = "";
 });
-
-// 백준 아이디가 바뀌면 검증 결과는 무효화
-// watch(baekjoonId, () => {
-//   if (!isEditingBaekjoonId.value) return;
-//   isBaekjoonValid.value = null;
-//   baekjoonCheckMessage.value = "";
-// });
 
 // ===== 3영역: 비밀번호 변경 =====
 const showPasswordSection = ref(false);

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch, onMounted } from "vue";
+import { ref, watch, onMounted, computed } from "vue";
 import { useRouter } from "vue-router";
 import { useAuthStore } from "@/data/authStore";
 import { authService } from "@/services/authService";
@@ -22,14 +22,14 @@ const email = ref("");
 const nickname = ref("");
 const originalNickname = ref("");
 const baekjoonId = ref("");
-const originalBaekjoonId = ref("");
+// const originalBaekjoonId = ref("");
 
 // 백준 아이디 수정 상태
-const isEditingBaekjoonId = ref(false);
-const isSavingBaekjoonId = ref(false);
-const isCheckingBaekjoonId = ref(false);
-const baekjoonCheckMessage = ref("");
-const isBaekjoonValid = ref(null); // null: 모름, true: 존재, false: 없음
+// const isEditingBaekjoonId = ref(false);
+// const isSavingBaekjoonId = ref(false);
+// const isCheckingBaekjoonId = ref(false);
+// const baekjoonCheckMessage = ref("");
+// const isBaekjoonValid = ref(null); // null: 모름, true: 존재, false: 없음
 
 // 닉네임 수정 상태
 const isEditingNickname = ref(false);
@@ -46,11 +46,11 @@ watch(nickname, () => {
 });
 
 // 백준 아이디가 바뀌면 검증 결과는 무효화
-watch(baekjoonId, () => {
-  if (!isEditingBaekjoonId.value) return;
-  isBaekjoonValid.value = null;
-  baekjoonCheckMessage.value = "";
-});
+// watch(baekjoonId, () => {
+//   if (!isEditingBaekjoonId.value) return;
+//   isBaekjoonValid.value = null;
+//   baekjoonCheckMessage.value = "";
+// });
 
 // ===== 3영역: 비밀번호 변경 =====
 const showPasswordSection = ref(false);
@@ -65,6 +65,8 @@ const showDeleteConfirm = ref(false);
 const deleteConfirmInput = ref("");
 const isDeleting = ref(false);
 const deleteError = ref("");
+
+const currentUserId = computed(() => authStore.user.value?.id ?? null);
 
 // ===== 기본 유저 정보 로드 (로그인 안 돼 있으면 Login으로) =====
 onMounted(async () => {
@@ -96,28 +98,43 @@ async function handleVerifyPassword() {
     return;
   }
 
+  const userId = currentUserId.value;
+  if (!userId) {
+    router.push({ name: "Login", query: { redirect: "/me" } });
+    return;
+  }
+
   verifyLoading.value = true;
   try {
-    const res = await authService.verifyPassword({ password: pwd });
+    const ok = await authService.verifyPassword({ userId, password: pwd }); // boolean
+    if (ok !== true) {
+      verifyError.value = "비밀번호가 올바르지 않습니다.";
+      return;
+    }
 
-    const user = res.user;
+    const user = await authService.getUserInfo({ id: userId });
+    if (!user) {
+      router.push({ name: "Login", query: { redirect: "/me" } });
+      return;
+    }
+
     email.value = user.email;
     nickname.value = user.nickname;
     originalNickname.value = user.nickname;
-    baekjoonId.value = user.baekjoonId || "";
-    originalBaekjoonId.value = user.baekjoonId || "";
+    baekjoonId.value =
+      user.baekjoonId ?? authStore.user.value?.baekjoonId ?? "";
 
     step.value = "profile";
     verifyPasswordInput.value = "";
     globalMessage.value = "본인 확인이 완료되었습니다.";
   } catch (e) {
-    if (e.code === "INVALID_PASSWORD") {
+    // 401이거나 커스텀 코드가 오거나 모두 커버
+    if (e?.code === "INVALID_PASSWORD" || e?.response?.status === 401) {
       verifyError.value = "비밀번호가 올바르지 않습니다.";
     } else {
       verifyError.value =
         "본인 확인 중 문제가 발생했습니다. 다시 시도해주세요.";
     }
-    console.log(e);
   } finally {
     verifyLoading.value = false;
   }
@@ -131,7 +148,6 @@ async function handleCheckNickname() {
   const value = nickname.value.trim();
   if (!value) {
     nicknameCheckMessage.value = "닉네임을 먼저 입력해주세요.";
-    isNicknameDuplicated.value = null;
     return;
   }
 
@@ -163,7 +179,7 @@ async function handleCheckNickname() {
     isNicknameDuplicated.value = null;
     nicknameCheckMessage.value =
       "닉네임 중복 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
-    console.log(e);
+    console.error(e);
   } finally {
     isCheckingNickname.value = false;
   }
@@ -186,6 +202,12 @@ function cancelEditNickname() {
 async function handleSaveNickname() {
   globalError.value = "";
   globalMessage.value = "";
+
+  const userId = currentUserId.value;
+  if (!userId) {
+    router.push({ name: "Login", query: { redirect: "/me" } });
+    return;
+  }
 
   const value = nickname.value.trim();
   if (!value) {
@@ -217,7 +239,10 @@ async function handleSaveNickname() {
   isSavingNickname.value = true;
 
   try {
-    const res = await authService.updateNickname({ nickname: value });
+    const res = await authService.updateNickname({
+      id: userId,
+      nickname: value,
+    });
     const user = res.user;
 
     nickname.value = user.nickname;
@@ -229,118 +254,13 @@ async function handleSaveNickname() {
     globalMessage.value = "닉네임이 변경되었습니다.";
 
     // 헤더/전역 상태 동기화
-    await authStore.fetchCurrentUser({ force: true });
+    authStore.updateUser({ nickname: user.nickname });
   } catch (e) {
     globalError.value =
       "닉네임을 변경하는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
-    console.log(e);
+    console.error(e);
   } finally {
     isSavingNickname.value = false;
-  }
-}
-
-// ===== 백준 아이디 확인 =====
-async function handleCheckBaekjoonId() {
-  baekjoonCheckMessage.value = "";
-  isBaekjoonValid.value = null;
-
-  const handle = baekjoonId.value.trim();
-  if (!handle) {
-    baekjoonCheckMessage.value = "백준 아이디를 먼저 입력해주세요.";
-    return;
-  }
-
-  // 지금 등록된 아이디와 동일하면 그냥 유효로 처리
-  if (handle === (originalBaekjoonId.value || "")) {
-    isBaekjoonValid.value = true;
-    baekjoonCheckMessage.value = "현재 등록된 백준 아이디입니다.";
-    return;
-  }
-
-  isCheckingBaekjoonId.value = true;
-
-  try {
-    const res = await authService.checkBaekjoonId({ handle });
-    if (res.exists) {
-      isBaekjoonValid.value = true;
-      baekjoonCheckMessage.value = "존재하는 백준 아이디입니다.";
-    } else {
-      isBaekjoonValid.value = false;
-      baekjoonCheckMessage.value =
-        "존재하지 않는 백준 아이디입니다. 다시 확인해주세요.";
-    }
-  } catch (e) {
-    console.error(e);
-    isBaekjoonValid.value = null;
-    baekjoonCheckMessage.value =
-      "백준 아이디 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
-  } finally {
-    isCheckingBaekjoonId.value = false;
-  }
-}
-
-function startEditBaekjoonId() {
-  isEditingBaekjoonId.value = true;
-  baekjoonCheckMessage.value = "";
-  isBaekjoonValid.value = null;
-}
-
-function cancelEditBaekjoonId() {
-  isEditingBaekjoonId.value = false;
-  baekjoonId.value = originalBaekjoonId.value || "";
-  baekjoonCheckMessage.value = "";
-  isBaekjoonValid.value = null;
-}
-
-// ===== 백준 아이디 저장 =====
-async function handleSaveBaekjoonId() {
-  globalError.value = "";
-  globalMessage.value = "";
-
-  const value = baekjoonId.value.trim();
-
-  if (!value) {
-    globalError.value = "백준 아이디를 비울 수 없습니다.";
-    return;
-  }
-
-  // 변경 없으면 그냥 종료
-  if (value === (originalBaekjoonId.value || "")) {
-    isEditingBaekjoonId.value = false;
-    baekjoonCheckMessage.value = "";
-    isBaekjoonValid.value = null;
-    return;
-  }
-
-  // 존재하지 않는 아이디면 막기
-  if (isBaekjoonValid.value !== true) {
-    globalError.value =
-      "백준 아이디가 실제로 존재하는지 확인 버튼을 눌러주세요.";
-    return;
-  }
-
-  isSavingBaekjoonId.value = true;
-
-  try {
-    const res = await authService.updateBaekjoonId({ baekjoonId: value });
-    const user = res.user;
-
-    baekjoonId.value = user.baekjoonId || "";
-    originalBaekjoonId.value = user.baekjoonId || "";
-
-    isEditingBaekjoonId.value = false;
-    baekjoonCheckMessage.value = "";
-    isBaekjoonValid.value = null;
-    globalMessage.value = "백준 아이디가 변경되었습니다.";
-
-    // 헤더/전역 상태 동기화
-    await authStore.fetchCurrentUser({ force: true });
-  } catch (e) {
-    globalError.value =
-      "백준 아이디를 변경하는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
-    console.log(e);
-  } finally {
-    isSavingBaekjoonId.value = false;
   }
 }
 
@@ -350,6 +270,12 @@ async function handleChangePassword() {
   passwordChangeMessage.value = "";
   globalError.value = "";
   globalMessage.value = "";
+
+  const userId = currentUserId.value;
+  if (!userId) {
+    router.push({ name: "Login", query: { redirect: "/me" } });
+    return;
+  }
 
   const pwd = newPassword.value.trim();
   const confirm = newPasswordConfirm.value.trim();
@@ -368,7 +294,7 @@ async function handleChangePassword() {
   isChangingPassword.value = true;
 
   try {
-    await authService.changePassword({ newPassword: pwd });
+    await authService.changePassword({ id: userId, newPassword: pwd });
 
     // 보안상 비밀번호 변경 후 세션 끊고 재로그인 요구
     await authStore.logout();
@@ -381,7 +307,7 @@ async function handleChangePassword() {
   } catch (e) {
     passwordChangeError.value =
       "비밀번호 변경 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
-    console.log(e);
+    console.error(e);
   } finally {
     isChangingPassword.value = false;
     newPassword.value = "";
@@ -395,6 +321,12 @@ async function handleDeleteAccount() {
   globalError.value = "";
   globalMessage.value = "";
 
+  const userId = currentUserId.value;
+  if (!userId) {
+    router.push({ name: "Login", query: { redirect: "/me" } });
+    return;
+  }
+
   if (deleteConfirmInput.value.trim() !== "탈퇴합니다") {
     deleteError.value =
       '확인 문구가 일치하지 않습니다. "탈퇴합니다"를 정확히 입력해주세요.';
@@ -402,32 +334,15 @@ async function handleDeleteAccount() {
   }
 
   isDeleting.value = true;
-
   try {
-    /**
-     * TODO: 실제 백엔드 전환 시에는 대략 이런 흐름으로:
-     *
-     * const summary = await getMyGroupSummary();
-     * if (summary.joinedCount && summary.joinedCount > 0) {
-     *   deleteError.value =
-     *     `현재 ${summary.joinedCount}개의 그룹에 속해 있습니다. ` +
-     *     "모든 그룹에서 탈퇴한 뒤 다시 시도해주세요.";
-     *   return;
-     * }
-     *
-     * await deleteMyAccount();
-     */
-    await authService.deleteAccount();
+    await authService.deleteAccount({ id: userId });
 
-    // 세션/스토어 정리
     await authStore.logout();
-
-    // 탈퇴 후에는 홈(또는 랜딩)으로 이동
     router.push({ name: "Home" });
   } catch (e) {
     deleteError.value =
       "회원 탈퇴 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
-    console.log(e);
+    console.error(e);
   } finally {
     isDeleting.value = false;
   }
@@ -513,6 +428,7 @@ async function handleDeleteAccount() {
 
             <button
               type="button"
+              data-testid="verify-submit"
               :disabled="verifyLoading"
               class="mt-1 inline-flex items-center justify-center rounded-lg bg-yellow-400 px-4 py-2 text-sm font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
               @click="handleVerifyPassword"
@@ -537,9 +453,9 @@ async function handleDeleteAccount() {
 
             <div class="mt-4 space-y-4">
               <div>
-                <label class="block text-xs font-medium text-gray-500 mb-1">
-                  이메일
-                </label>
+                <label class="block text-xs font-medium text-gray-500 mb-1"
+                  >이메일</label
+                >
                 <div
                   class="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700"
                 >
@@ -549,74 +465,19 @@ async function handleDeleteAccount() {
               </div>
 
               <div>
-                <label
-                  for="mypage-baekjoon-id"
-                  class="block text-xs font-medium text-gray-500 mb-1"
+                <label class="block text-xs font-medium text-gray-500 mb-1"
+                  >백준 아이디</label
                 >
-                  백준 아이디
-                </label>
-
-                <div class="flex gap-2 items-center">
-                  <input
-                    id="mypage-baekjoon-id"
-                    v-model="baekjoonId"
-                    :disabled="!isEditingBaekjoonId"
-                    type="text"
-                    class="flex-1 rounded-lg border border-gray-200 bg-white/70 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 disabled:bg-gray-50 disabled:text-gray-500"
-                    placeholder="백준 온라인 저지 아이디"
-                  />
-                  <button
-                    v-if="!isEditingBaekjoonId"
-                    type="button"
-                    class="shrink-0 rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100"
-                    @click="startEditBaekjoonId"
-                  >
-                    아이디 수정
-                  </button>
-                </div>
-
-                <!-- 백준 아이디 수정 모드 -->
                 <div
-                  v-if="isEditingBaekjoonId"
-                  class="mt-2 flex flex-wrap items-center gap-2"
+                  data-testid="baekjoon-display"
+                  class="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700"
                 >
-                  <button
-                    type="button"
-                    class="rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
-                    :disabled="isCheckingBaekjoonId || !baekjoonId.trim()"
-                    @click="handleCheckBaekjoonId"
-                  >
-                    <span v-if="!isCheckingBaekjoonId">아이디 확인</span>
-                    <span v-else>확인 중...</span>
-                  </button>
-
-                  <button
-                    type="button"
-                    class="rounded-lg bg-yellow-400 px-3 py-1.5 text-xs font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed"
-                    :disabled="isSavingBaekjoonId"
-                    @click="handleSaveBaekjoonId"
-                  >
-                    <span v-if="!isSavingBaekjoonId">저장</span>
-                    <span v-else>저장 중...</span>
-                  </button>
-
-                  <button
-                    type="button"
-                    class="rounded-lg border border-transparent px-2 py-1 text-xs text-gray-500 hover:text-gray-700"
-                    @click="cancelEditBaekjoonId"
-                  >
-                    취소
-                  </button>
+                  <span>{{ baekjoonId || "-" }}</span>
+                  <span class="text-[11px] text-gray-400"> 수정 불가 </span>
                 </div>
-
-                <p
-                  v-if="baekjoonCheckMessage"
-                  class="mt-1 text-xs"
-                  :class="
-                    isBaekjoonValid === true ? 'text-green-600' : 'text-red-600'
-                  "
-                >
-                  {{ baekjoonCheckMessage }}
+                <p class="mt-1 text-xs text-gray-400">
+                  백준 아이디는 계정 생성 시 등록되며, 마이페이지에서 변경할 수
+                  없습니다.
                 </p>
               </div>
 
@@ -640,6 +501,7 @@ async function handleDeleteAccount() {
                   <button
                     v-if="!isEditingNickname"
                     type="button"
+                    data-testid="nickname-edit"
                     class="shrink-0 rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100"
                     @click="startEditNickname"
                   >
@@ -647,13 +509,13 @@ async function handleDeleteAccount() {
                   </button>
                 </div>
 
-                <!-- 닉네임 수정 모드일 때만 보이는 영역 -->
                 <div
                   v-if="isEditingNickname"
                   class="mt-2 flex flex-wrap items-center gap-2"
                 >
                   <button
                     type="button"
+                    data-testid="nickname-check"
                     class="rounded-lg border border-gray-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
                     :disabled="isCheckingNickname || !nickname.trim()"
                     @click="handleCheckNickname"
@@ -664,6 +526,7 @@ async function handleDeleteAccount() {
 
                   <button
                     type="button"
+                    data-testid="nickname-save"
                     class="rounded-lg bg-yellow-400 px-3 py-1.5 text-xs font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed"
                     :disabled="isSavingNickname"
                     @click="handleSaveNickname"
@@ -674,6 +537,7 @@ async function handleDeleteAccount() {
 
                   <button
                     type="button"
+                    data-testid="nickname-cancel"
                     class="rounded-lg border border-transparent px-2 py-1 text-xs text-gray-500 hover:text-gray-700"
                     @click="cancelEditNickname"
                   >
@@ -710,6 +574,7 @@ async function handleDeleteAccount() {
               </div>
               <button
                 type="button"
+                data-testid="password-toggle"
                 class="text-xs text-gray-500 hover:text-gray-700 underline-offset-2 hover:underline"
                 @click="showPasswordSection = !showPasswordSection"
               >
@@ -770,6 +635,7 @@ async function handleDeleteAccount() {
 
               <button
                 type="button"
+                data-testid="password-submit"
                 :disabled="isChangingPassword"
                 class="inline-flex items-center justify-center rounded-lg bg-yellow-400 px-4 py-2 text-sm font-semibold text-gray-900 shadow-sm hover:bg-yellow-300 disabled:opacity-60 disabled:cursor-not-allowed"
                 @click="handleChangePassword"
@@ -792,6 +658,7 @@ async function handleDeleteAccount() {
               </div>
               <button
                 type="button"
+                data-testid="delete-toggle"
                 class="text-xs font-medium text-red-700 hover:text-red-800 underline-offset-2 hover:underline"
                 @click="
                   showDeleteConfirm = !showDeleteConfirm;
@@ -815,6 +682,7 @@ async function handleDeleteAccount() {
 
               <input
                 v-model="deleteConfirmInput"
+                data-testid="delete-input"
                 type="text"
                 class="block w-full rounded-lg border border-red-200 bg-white/80 px-3 py-2 text-sm shadow-sm placeholder:text-red-300 focus:outline-none focus:ring-2 focus:ring-red-300 focus:border-red-300"
                 placeholder="탈퇴합니다 를 입력해주세요"
@@ -829,6 +697,7 @@ async function handleDeleteAccount() {
 
               <button
                 type="button"
+                data-testid="delete-confirm"
                 :disabled="
                   isDeleting || deleteConfirmInput.trim() !== '탈퇴합니다'
                 "

--- a/tests/MyPageView.spec.js
+++ b/tests/MyPageView.spec.js
@@ -24,6 +24,7 @@ vi.mock("@/data/authStore", () => {
   if (!g.initializedRef) g.initializedRef = ref(false);
   if (!g.fetchCurrentUserMock) g.fetchCurrentUserMock = vi.fn(async () => {});
   if (!g.logoutMock) g.logoutMock = vi.fn(async () => {});
+  if (!g.updateUserMock) g.updateUserMock = vi.fn(() => {});
 
   return {
     useAuthStore: () => ({
@@ -31,6 +32,7 @@ vi.mock("@/data/authStore", () => {
       initialized: g.initializedRef,
       fetchCurrentUser: g.fetchCurrentUserMock,
       logout: g.logoutMock,
+      updateUser: g.updateUserMock,
     }),
   };
 });
@@ -40,11 +42,10 @@ vi.mock("@/data/authStore", () => {
 // =======================
 vi.mock("@/services/authService", () => ({
   authService: {
-    verifyPassword: vi.fn(),
+    verifyPassword: vi.fn(), // boolean
+    getUserInfo: vi.fn(), // { id, email, nickname }
     checkUsernameDuplicate: vi.fn(),
-    updateNickname: vi.fn(),
-    checkBaekjoonId: vi.fn(),
-    updateBaekjoonId: vi.fn(),
+    updateNickname: vi.fn(), // { user }
     changePassword: vi.fn(),
     deleteAccount: vi.fn(),
   },
@@ -59,8 +60,7 @@ async function goToProfileStep(wrapper, overrides = {}) {
   wrapper.vm.email = overrides.email ?? "user@example.com";
   wrapper.vm.nickname = overrides.nickname ?? "oldNick";
   wrapper.vm.originalNickname = overrides.originalNickname ?? "oldNick";
-  wrapper.vm.baekjoonId = overrides.baekjoonId ?? "";
-  wrapper.vm.originalBaekjoonId = overrides.originalBaekjoonId ?? "";
+  wrapper.vm.baekjoonId = overrides.baekjoonId ?? "tourist";
   await nextTick();
 }
 
@@ -76,10 +76,12 @@ describe("MyPageView.vue", () => {
         id: 1,
         email: "user@example.com",
         nickname: "oldNick",
+        baekjoonId: "tourist",
       };
       g.initializedRef.value = true;
       g.fetchCurrentUserMock.mockReset();
       g.logoutMock.mockReset();
+      g.updateUserMock.mockReset();
     }
 
     pushMock.mockReset();
@@ -105,32 +107,28 @@ describe("MyPageView.vue", () => {
 
   it("비밀번호 재확인에서 8자 미만이면 에러를 보여주고 API를 호출하지 않는다", async () => {
     const verifySpy = authService.verifyPassword;
-    verifySpy.mockResolvedValue({});
+    verifySpy.mockResolvedValue(true);
 
     const wrapper = mount(MyPageView);
     await flushPromises();
 
     await wrapper.get("#verify-password").setValue("short");
-
-    const verifyBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("본인 확인하기"));
-
-    await verifyBtn.trigger("click");
+    await wrapper.get('[data-testid="verify-submit"]').trigger("click");
     await flushPromises();
 
     expect(wrapper.text()).toContain("비밀번호는 최소 8자 이상이어야 합니다.");
     expect(verifySpy).not.toHaveBeenCalled();
   });
 
-  it("올바른 비밀번호 입력 시 authService.verifyPassword 호출 후 프로필 단계로 전환되고, 이메일/닉네임/백준 아이디가 세팅된다", async () => {
+  it("올바른 비밀번호 입력 시 verifyPassword(userId,pwd) -> getUserInfo 호출 후 프로필 단계로 전환된다", async () => {
     const verifySpy = authService.verifyPassword;
-    verifySpy.mockResolvedValue({
-      user: {
-        email: "me@example.com",
-        nickname: "myNick",
-        baekjoonId: "tourist",
-      },
+    verifySpy.mockResolvedValue(true);
+
+    const getInfoSpy = authService.getUserInfo;
+    getInfoSpy.mockResolvedValue({
+      id: 1,
+      email: "me@example.com",
+      nickname: "myNick",
     });
 
     const wrapper = mount(MyPageView);
@@ -138,13 +136,14 @@ describe("MyPageView.vue", () => {
 
     await wrapper.get("#verify-password").setValue("password123");
 
-    const verifyBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("본인 확인하기"));
-    await verifyBtn.trigger("click");
+    await wrapper.get('[data-testid="verify-submit"]').trigger("click");
     await flushPromises();
 
-    expect(verifySpy).toHaveBeenCalledWith({ password: "password123" });
+    expect(verifySpy).toHaveBeenCalledWith({
+      userId: 1,
+      password: "password123",
+    });
+    expect(getInfoSpy).toHaveBeenCalledWith({ id: 1 });
 
     // 전역 메시지 + 프로필 영역 표시
     expect(wrapper.text()).toContain("본인 확인이 완료되었습니다.");
@@ -153,28 +152,30 @@ describe("MyPageView.vue", () => {
 
     const nicknameInput = wrapper.get("#mypage-nickname");
     expect(nicknameInput.element.value).toBe("myNick");
-
-    const baekjoonInput = wrapper.get("#mypage-baekjoon-id");
-    expect(baekjoonInput.element.value).toBe("tourist");
   });
 
   it("비밀번호가 틀리면 에러 메시지를 보여준다", async () => {
     const verifySpy = authService.verifyPassword;
-    verifySpy.mockRejectedValue({ code: "INVALID_PASSWORD" });
+    verifySpy.mockRejectedValue({ response: { status: 401 } });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
 
     await wrapper.get("#verify-password").setValue("wrongpass");
-
-    const verifyBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("본인 확인하기"));
-    await verifyBtn.trigger("click");
+    await wrapper.get('[data-testid="verify-submit"]').trigger("click");
     await flushPromises();
 
     expect(verifySpy).toHaveBeenCalled();
     expect(wrapper.text()).toContain("비밀번호가 올바르지 않습니다.");
+  });
+
+  it("백준 아이디 수정 UI가 노출되지 않는다(정책 반영)", async () => {
+    const wrapper = mount(MyPageView);
+    await flushPromises();
+    await goToProfileStep(wrapper);
+
+    expect(wrapper.text()).not.toContain("아이디 수정");
+    expect(wrapper.find("#mypage-baekjoon-id").exists()).toBe(false);
   });
 
   it("닉네임 중복 확인에서 사용 가능한 닉네임이면 메시지를 표시한다", async () => {
@@ -189,26 +190,17 @@ describe("MyPageView.vue", () => {
     await goToProfileStep(wrapper);
 
     // 닉네임 수정 모드 진입
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("닉네임 수정"));
-    await editBtn.trigger("click");
-
+    await wrapper.get('[data-testid="nickname-edit"]').trigger("click");
     await wrapper.get("#mypage-nickname").setValue("newNick");
 
-    const checkBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("중복 확인"));
-    expect(checkBtn).toBeTruthy();
-
-    await checkBtn.trigger("click");
+    await wrapper.get('[data-testid="nickname-check"]').trigger("click");
     await flushPromises();
 
     expect(checkSpy).toHaveBeenCalledWith({ username: "newNick" });
     expect(wrapper.text()).toContain("사용 가능한 닉네임입니다.");
   });
 
-  it("닉네임 중복 확인 없이 저장 시 에러를 보여주고 authService.updateNickname을 호출하지 않는다", async () => {
+  it("닉네임 중복 확인 없이 저장 시 에러를 보여주고 updateNickname을 호출하지 않는다", async () => {
     const updateSpy = authService.updateNickname;
     updateSpy.mockResolvedValue({
       user: {
@@ -221,24 +213,17 @@ describe("MyPageView.vue", () => {
     await flushPromises();
     await goToProfileStep(wrapper);
 
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("닉네임 수정"));
-    await editBtn.trigger("click");
-
+    await wrapper.get('[data-testid="nickname-edit"]').trigger("click");
     await wrapper.get("#mypage-nickname").setValue("newNick");
 
-    const saveBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("저장"));
-    await saveBtn.trigger("click");
+    await wrapper.get('[data-testid="nickname-save"]').trigger("click");
     await flushPromises();
 
     expect(wrapper.text()).toContain("닉네임 중복 확인 후 저장해주세요.");
     expect(updateSpy).not.toHaveBeenCalled();
   });
 
-  it("닉네임 중복 확인 후 저장 시 authService.checkUsernameDuplicate과 authService.updateNickname를 호출한다", async () => {
+  it("닉네임 중복 확인 후 저장 시 checkUsernameDuplicate + updateNickname(id,nickname) 호출, store는 updateUser로 동기화한다", async () => {
     const g = globalThis.__authMocks;
 
     const checkSpy = authService.checkUsernameDuplicate;
@@ -249,260 +234,49 @@ describe("MyPageView.vue", () => {
 
     const updateSpy = authService.updateNickname;
     updateSpy.mockResolvedValue({
-      user: {
-        email: "user@example.com",
-        nickname: "newNick",
-      },
+      user: { id: 1, email: "user@example.com", nickname: "newNick" },
     });
 
     const wrapper = mount(MyPageView);
     await flushPromises();
     await goToProfileStep(wrapper);
 
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("닉네임 수정"));
-    await editBtn.trigger("click");
-
+    await wrapper.get('[data-testid="nickname-edit"]').trigger("click");
     await wrapper.get("#mypage-nickname").setValue("newNick");
 
-    const checkBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("중복 확인"));
-    await checkBtn.trigger("click");
+    await wrapper.get('[data-testid="nickname-check"]').trigger("click");
     await flushPromises();
 
-    const saveBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("저장"));
-    await saveBtn.trigger("click");
+    await wrapper.get('[data-testid="nickname-save"]').trigger("click");
     await flushPromises();
 
-    expect(checkSpy).toHaveBeenCalled();
-    expect(updateSpy).toHaveBeenCalledWith({ nickname: "newNick" });
-    expect(g.fetchCurrentUserMock).toHaveBeenCalledWith({ force: true });
+    expect(checkSpy).toHaveBeenCalledWith({ username: "newNick" });
+    expect(updateSpy).toHaveBeenCalledWith({ id: 1, nickname: "newNick" });
+
+    expect(g.updateUserMock).toHaveBeenCalledWith({ nickname: "newNick" });
+    expect(g.fetchCurrentUserMock).not.toHaveBeenCalledWith({ force: true });
+
     expect(wrapper.text()).toContain("닉네임이 변경되었습니다.");
   });
 
-  // ============================
-  // 백준 아이디 관련 테스트
-  // ============================
-
-  it("백준 아이디 입력이 없으면 '아이디 확인' 버튼이 비활성화되고 authService.checkBaekjoonId를 호출하지 않는다", async () => {
-    const checkSpy = authService.checkBaekjoonId;
-    checkSpy.mockResolvedValue({ exists: true });
-
+  it("백준 아이디가 이메일처럼 표시되고, 수정 버튼은 노출되지 않는다", async () => {
     const wrapper = mount(MyPageView);
     await flushPromises();
+    await goToProfileStep(wrapper, { baekjoonId: "tourist" });
 
-    // 프로필 단계 & 백준 아이디 없음으로 세팅
-    await goToProfileStep(wrapper, {
-      baekjoonId: "",
-      originalBaekjoonId: "",
-    });
+    const box = wrapper.get('[data-testid="baekjoon-display"]');
+    expect(box.text()).toContain("tourist");
+    expect(box.text()).toContain("수정 불가");
 
-    // "아이디 수정" 눌러서 편집 모드 진입
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 수정"));
-    await editBtn.trigger("click");
-    await flushPromises();
-
-    // "아이디 확인" 버튼 찾기
-    const checkBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 확인"));
-
-    // 입력이 없으므로 버튼이 비활성화되어 있어야 한다
-    expect(checkBtn.element.disabled).toBe(true);
-
-    // 클릭해도 실제 API는 호출되지 않아야 한다
-    await checkBtn.trigger("click");
-    await flushPromises();
-
-    expect(checkSpy).not.toHaveBeenCalled();
-  });
-
-  it("현재 등록된 백준 아이디와 동일한 값을 확인하면 API 호출 없이 유효 처리한다", async () => {
-    const checkSpy = authService.checkBaekjoonId;
-    checkSpy.mockResolvedValue({ exists: true });
-
-    const wrapper = mount(MyPageView);
-    await flushPromises();
-    await goToProfileStep(wrapper, {
-      baekjoonId: "tourist",
-      originalBaekjoonId: "tourist",
-    });
-
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 수정"));
-    await editBtn.trigger("click");
-    await flushPromises();
-
-    const checkBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 확인"));
-    await checkBtn.trigger("click");
-    await flushPromises();
-
-    expect(checkSpy).not.toHaveBeenCalled();
-    expect(wrapper.text()).toContain("현재 등록된 백준 아이디입니다.");
-  });
-
-  it("존재하는 백준 아이디라면 아이디 확인 시 성공 메시지를 보여준다", async () => {
-    const checkSpy = authService.checkBaekjoonId;
-    checkSpy.mockResolvedValue({ exists: true });
-
-    const wrapper = mount(MyPageView);
-    await flushPromises();
-    await goToProfileStep(wrapper, {
-      baekjoonId: "",
-      originalBaekjoonId: "",
-    });
-
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 수정"));
-    await editBtn.trigger("click");
-    await flushPromises();
-
-    await wrapper.get("#mypage-baekjoon-id").setValue("tourist");
-
-    const checkBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 확인"));
-    await checkBtn.trigger("click");
-    await flushPromises();
-
-    expect(checkSpy).toHaveBeenCalledWith({ handle: "tourist" });
-    expect(wrapper.text()).toContain("존재하는 백준 아이디입니다.");
-  });
-
-  it("백준 아이디 확인 없이 저장 시 에러를 보여주고 authService.updateBaekjoonId를 호출하지 않는다", async () => {
-    const updateSpy = authService.updateBaekjoonId;
-    updateSpy.mockResolvedValue({
-      user: {
-        email: "user@example.com",
-        nickname: "oldNick",
-        baekjoonId: "tourist",
-      },
-    });
-
-    const wrapper = mount(MyPageView);
-    await flushPromises();
-    await goToProfileStep(wrapper, {
-      baekjoonId: "",
-      originalBaekjoonId: "",
-    });
-
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 수정"));
-    await editBtn.trigger("click");
-    await flushPromises();
-
-    await wrapper.get("#mypage-baekjoon-id").setValue("tourist");
-
-    const saveBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("저장"));
-    await saveBtn.trigger("click");
-    await flushPromises();
-
-    expect(wrapper.text()).toContain(
-      "백준 아이디가 실제로 존재하는지 확인 버튼을 눌러주세요.",
-    );
-    expect(updateSpy).not.toHaveBeenCalled();
-  });
-
-  it("백준 아이디 확인 후 저장 시 authService.checkBaekjoonId와 fetchCurrentUser를 호출한다", async () => {
-    const g = globalThis.__authMocks;
-
-    const checkSpy = authService.checkBaekjoonId;
-    checkSpy.mockResolvedValue({ exists: true });
-
-    const updateSpy = authService.updateBaekjoonId;
-    updateSpy.mockResolvedValue({
-      user: {
-        email: "user@example.com",
-        nickname: "oldNick",
-        baekjoonId: "tourist",
-      },
-    });
-
-    const wrapper = mount(MyPageView);
-    await flushPromises();
-    await goToProfileStep(wrapper, {
-      baekjoonId: "",
-      originalBaekjoonId: "",
-    });
-
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 수정"));
-    await editBtn.trigger("click");
-    await flushPromises();
-
-    await wrapper.get("#mypage-baekjoon-id").setValue("tourist");
-
-    const checkBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 확인"));
-    await checkBtn.trigger("click");
-    await flushPromises();
-
-    const saveBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("저장"));
-    await saveBtn.trigger("click");
-    await flushPromises();
-
-    expect(checkSpy).toHaveBeenCalledWith({ handle: "tourist" });
-    expect(updateSpy).toHaveBeenCalledWith({ baekjoonId: "tourist" });
-    expect(g.fetchCurrentUserMock).toHaveBeenCalledWith({ force: true });
-    expect(wrapper.text()).toContain("백준 아이디가 변경되었습니다.");
-  });
-
-  it("백준 아이디를 빈 문자열로 저장하려 하면 에러를 보여주고 authService.updateBaekjoonId를 호출하지 않는다", async () => {
-    const updateSpy = authService.updateBaekjoonId;
-    updateSpy.mockResolvedValue({
-      user: {
-        email: "user@example.com",
-        nickname: "oldNick",
-        baekjoonId: "",
-      },
-    });
-
-    const wrapper = mount(MyPageView);
-    await flushPromises();
-    await goToProfileStep(wrapper, {
-      baekjoonId: "tourist",
-      originalBaekjoonId: "tourist",
-    });
-
-    const editBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("아이디 수정"));
-    await editBtn.trigger("click");
-    await flushPromises();
-
-    await wrapper.get("#mypage-baekjoon-id").setValue("");
-    const saveBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("저장"));
-    await saveBtn.trigger("click");
-    await flushPromises();
-
-    expect(wrapper.text()).toContain("백준 아이디를 비울 수 없습니다.");
-    expect(updateSpy).not.toHaveBeenCalled();
+    expect(wrapper.text()).not.toContain("아이디 수정");
+    expect(wrapper.text()).not.toContain("아이디 확인");
   });
 
   // ============================
   // 비밀번호 / 탈퇴 기존 테스트
   // ============================
 
-  it("비밀번호 변경에서 8자 미만이면 에러를 보여주고 authService.changePassword를 호출하지 않는다", async () => {
+  it("비밀번호 변경에서 8자 미만이면 에러를 보여주고 changePassword를 호출하지 않는다", async () => {
     const changeSpy = authService.changePassword;
     changeSpy.mockResolvedValue({});
 
@@ -511,26 +285,20 @@ describe("MyPageView.vue", () => {
     await goToProfileStep(wrapper);
 
     // 비밀번호 변경 영역 열기
-    const openBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("열기"));
-    await openBtn.trigger("click");
+    await wrapper.get('[data-testid="password-toggle"]').trigger("click");
     await flushPromises();
 
     await wrapper.get("#mypage-new-password").setValue("short");
     await wrapper.get("#mypage-new-password-confirm").setValue("short");
 
-    const changeBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("비밀번호 변경하기"));
-    await changeBtn.trigger("click");
+    await wrapper.get('[data-testid="password-submit"]').trigger("click");
     await flushPromises();
 
     expect(wrapper.text()).toContain("비밀번호는 최소 8자 이상이어야 합니다.");
     expect(changeSpy).not.toHaveBeenCalled();
   });
 
-  it("비밀번호 변경 성공 시 authService.changePassword와 logout을 호출하고 Login으로 이동한다", async () => {
+  it("비밀번호 변경 성공 시 changePassword(id,newPassword) + logout 호출 후 Login으로 이동한다", async () => {
     const g = globalThis.__authMocks;
 
     const changeSpy = authService.changePassword;
@@ -540,10 +308,7 @@ describe("MyPageView.vue", () => {
     await flushPromises();
     await goToProfileStep(wrapper);
 
-    const openBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("열기"));
-    await openBtn.trigger("click");
+    await wrapper.get('[data-testid="password-toggle"]').trigger("click");
     await flushPromises();
 
     await wrapper.get("#mypage-new-password").setValue("newPassword123");
@@ -551,13 +316,11 @@ describe("MyPageView.vue", () => {
       .get("#mypage-new-password-confirm")
       .setValue("newPassword123");
 
-    const changeBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("비밀번호 변경하기"));
-    await changeBtn.trigger("click");
+    await wrapper.get('[data-testid="password-submit"]').trigger("click");
     await flushPromises();
 
     expect(changeSpy).toHaveBeenCalledWith({
+      id: 1,
       newPassword: "newPassword123",
     });
     expect(g.logoutMock).toHaveBeenCalled();
@@ -567,7 +330,7 @@ describe("MyPageView.vue", () => {
     });
   });
 
-  it("회원 탈퇴 확인 후 authService.deleteAccount와 logout을 호출하고 Home으로 이동한다", async () => {
+  it("회원 탈퇴 확인 후 deleteAccount(id)와 logout을 호출하고 Home으로 이동한다", async () => {
     const g = globalThis.__authMocks;
 
     const deleteSpy = authService.deleteAccount;
@@ -577,25 +340,19 @@ describe("MyPageView.vue", () => {
     await flushPromises();
     await goToProfileStep(wrapper);
 
-    const toggleDeleteBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("탈퇴하기"));
-    await toggleDeleteBtn.trigger("click");
+    await wrapper.get('[data-testid="delete-toggle"]').trigger("click");
     await flushPromises();
 
-    const input = wrapper.get("input[placeholder*='탈퇴합니다']");
-    await input.setValue("탈퇴합니다");
+    await wrapper.get('[data-testid="delete-input"]').setValue("탈퇴합니다");
     await flushPromises();
 
-    const confirmBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("정말 탈퇴하기"));
+    const confirmBtn = wrapper.get('[data-testid="delete-confirm"]');
     expect(confirmBtn.element.disabled).toBe(false);
 
     await confirmBtn.trigger("click");
     await flushPromises();
 
-    expect(deleteSpy).toHaveBeenCalled();
+    expect(deleteSpy).toHaveBeenCalledWith({ id: 1 });
     expect(g.logoutMock).toHaveBeenCalled();
     expect(pushMock).toHaveBeenCalledWith({ name: "Home" });
   });


### PR DESCRIPTION
이슈 번호 : https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/60
---

## ✅ 구현 내용

* **MyPage 재인증(비밀번호 재확인) 플로우를 Swagger 확정 API에 맞게 변경**

  * `POST /api/v1/auth/password/verify` 결과가 `boolean`이므로, 성공 시 **`GET /api/v1/users/{id}`로 프로필 정보 로드**하도록 수정
* **`GET /api/v1/users/{id}` 응답 스키마 변경 반영**

  * `userId` / `baekjoonHandle` 기반으로 FE 도메인(`id`, `nickname`, `baekjoonId`)에 매핑
  * status/createdAt/updatedAt 등 확장 필드도 수용 가능하도록 정리
* **백준 아이디(baekjoonHandle)는 수정 불가 정책 반영**

  * 마이페이지에서 **수정/검증/저장 기능 제거**
  * 대신 이메일처럼 **read-only로 표시**(없으면 `-`)
* **스토어 동기화 개선**

  * 닉네임 변경 후 real 모드에서 `fetchCurrentUser(force)`를 호출하지 않아도 되도록
  * `authStore.updateUser()`로 **부분 업데이트(예: nickname) 지원**
* **테스트 안정성 강화**

  * MyPageView 테스트를 신규 플로우에 맞게 갱신(verify → userInfo 조회)
  * UI 문구 변경에 덜 깨지도록 `data-testid` 기반으로 주요 버튼/입력 요소 접근

---

## 📂 변경 모듈

* `src/api/userApi.js`

  * `GET /users/{id}` 신규 스키마 대응
  * username/password 변경, 탈퇴 API 유지
* `src/api/authApi.js`

  * `POST /auth/password/verify` 클라이언트 추가
* `src/data/authStore.js`

  * `updateUser(patch)` 액션 추가 (닉네임 등 부분 동기화)
* `src/services/authService.js`

  * 서버 응답(`userId`, `username`, `baekjoonHandle`) → FE 도메인 매핑
  * verify(boolean) → getUserInfo 연동 구조 반영
* `src/views/MyPageView.vue`

  * verify 성공 후 userInfo 로딩
  * 백준 핸들 read-only 표시 / 수정 UI 제거
  * 주요 액션에 `data-testid` 부여
* `tests/MyPageView.spec.js`

  * 신규 verify/userInfo 흐름에 맞춰 테스트 수정
  * 백준 수정 관련 테스트 제거/대체(표시 확인)

---

## 🧪 시나리오

1. **마이페이지 진입**

   * 로그인 상태가 아니면 `Login?redirect=/me`로 이동
2. **본인 확인(비밀번호 재확인)**

   * 8자 미만 입력 시 검증 에러 노출, API 호출 없음
   * 올바른 비밀번호 입력 시

     * `authService.verifyPassword({ userId, password })` 호출
     * 성공(true) → `authService.getUserInfo({ id })` 호출
     * 프로필 화면으로 전환 + email/nickname/baekjoonHandle 표시
   * 틀린 비밀번호(401 등) 시 “비밀번호가 올바르지 않습니다.” 노출
3. **닉네임 변경**

   * 수정 모드 진입 → 중복 확인 → 저장
   * 저장 후 `authStore.updateUser({ nickname })`로 헤더/전역 닉네임 즉시 반영
4. **비밀번호 변경**

   * 검증(8자/일치 여부) 후 변경 성공 시 logout → `Login?reason=passwordChanged`
5. **회원 탈퇴**

   * 확인 문구 입력 후 탈퇴 진행 → logout → Home 이동
6. **백준 아이디**

   * 마이페이지에서 **수정 불가**
   * 이메일처럼 read-only로 표시 (없으면 `-`)

---

## 💡 기타

* `GET /users/{id}` 응답에 `baekjoonHandle`이 포함되어 있어, FE에서는 이를 `baekjoonId`로 매핑해 표시합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 비밀번호 검증 추가 및 사용자 정보 조회/관리(닉네임 변경·비밀번호 변경·계정 삭제) API 제공
  * 사용자 컨텍스트(id) 기반 인증 흐름 및 마이페이지 연동 지원

* **리팩토링**
  * 마이페이지 UI 단순화: 특정 아이디 읽기 전용, 닉네임 흐름 및 전역 사용자 갱신 정비
  * 인증 서비스에서 사용자 매핑/흐름 통합

* **테스트**
  * data-testid 추가 및 테스트 시나리오·모킹 확장 (getUserInfo, updateUser 등)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->