### PR TITLE
[BSM-62] feat: persist session with localStorage and support redirect

### DIFF
--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -1,4 +1,9 @@
 import axios from "axios";
+import {
+  TOKEN_STORAGE_KEY,
+  USER_STORAGE_KEY,
+  LOGOUT_EVENT,
+} from "../constants/auth";
 
 // .env에 VITE_API_BASE_URL 설정해두면 거기를 기본으로 사용
 // 예: VITE_API_BASE_URL=http://localhost:8080/api
@@ -9,10 +14,6 @@ const httpClient = axios.create({
     "Content-Type": "application/json",
   },
 });
-
-const TOKEN_STORAGE_KEY = "bsm_access_token";
-const USER_STORAGE_KEY = "bsm_user";
-const LOGOUT_EVENT = "bsm:auth:logout";
 
 // ===== JWT 전환 대비용: accessToken 관리 =====
 let accessToken = null;

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -10,17 +10,36 @@ const httpClient = axios.create({
   },
 });
 
+const TOKEN_STORAGE_KEY = "bsm_access_token";
+const USER_STORAGE_KEY = "bsm_user";
+const LOGOUT_EVENT = "bsm:auth:logout";
+
 // ===== JWT 전환 대비용: accessToken 관리 =====
 let accessToken = null;
 
+if (typeof window !== "undefined") {
+  const stored = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+  if (stored) accessToken = stored;
+}
+
 // 지금은 안 써도 됨. 나중에 로그인 성공 시 여기로 토큰 넣으면 됨.
 export function setAccessToken(token) {
-  accessToken = token;
+  accessToken = token ?? null;
+
+  if (typeof window !== "undefined") {
+    if (accessToken)
+      window.localStorage.setItem(TOKEN_STORAGE_KEY, accessToken);
+    else window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  }
 }
 
 // 로그아웃/만료 시 호출
 export function clearAccessToken() {
   accessToken = null;
+
+  if (typeof window !== "undefined") {
+    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  }
 }
 
 // === request 인터셉터: 토큰이 있으면 Authorization 헤더에 붙이기 ===
@@ -39,8 +58,16 @@ httpClient.interceptors.request.use(
 httpClient.interceptors.response.use(
   (response) => response,
   async (error) => {
-    // 나중에:
-    // if (error.response?.status === 401) { ...refresh 처리... }
+    if (error?.response?.status === 401) {
+      // 토큰/유저 캐시 정리
+      clearAccessToken();
+
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(USER_STORAGE_KEY);
+        // store도 즉시 반응하도록 이벤트 발행
+        window.dispatchEvent(new Event(LOGOUT_EVENT));
+      }
+    }
     return Promise.reject(error);
   },
 );

--- a/src/constants/auth.js
+++ b/src/constants/auth.js
@@ -1,0 +1,3 @@
+export const TOKEN_STORAGE_KEY = "bsm_access_token";
+export const USER_STORAGE_KEY = "bsm_user";
+export const LOGOUT_EVENT = "bsm:auth:logout";

--- a/src/data/authStore.js
+++ b/src/data/authStore.js
@@ -1,8 +1,6 @@
 import { reactive, computed, readonly } from "vue";
 import { authService } from "@/services/authService";
-
-const USER_STORAGE_KEY = "bsm_user";
-const LOGOUT_EVENT = "bsm:auth:logout";
+import { USER_STORAGE_KEY, LOGOUT_EVENT } from "../constants/auth";
 
 const state = reactive({
   user: null, // { id, email, nickname, ... }

--- a/src/data/authStore.js
+++ b/src/data/authStore.js
@@ -1,6 +1,9 @@
 import { reactive, computed, readonly } from "vue";
 import { authService } from "@/services/authService";
 
+const USER_STORAGE_KEY = "bsm_user";
+const LOGOUT_EVENT = "bsm:auth:logout";
+
 const state = reactive({
   user: null, // { id, email, nickname, ... }
   isLoading: false, // 로그인/로그아웃 버튼 로딩
@@ -9,17 +12,44 @@ const state = reactive({
   error: null,
 });
 
+function saveUserToStorage(user) {
+  if (typeof window === "undefined") return;
+  try {
+    if (user)
+      window.localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(user));
+  } catch (e) {
+    console.warn("[authStore] saveUserToStorage failed:", e);
+  }
+}
+
+function clearUserFromStorage() {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(USER_STORAGE_KEY);
+}
+
 function setUser(user) {
-  state.user = user;
+  state.user = user ?? null;
+
+  if (state.user) saveUserToStorage(state.user);
+  else clearUserFromStorage();
 }
 
 function clearUser() {
   state.user = null;
+  clearUserFromStorage();
 }
 
 function updateUser(patch) {
   if (!state.user) return;
   state.user = { ...state.user, ...patch };
+  saveUserToStorage(state.user);
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener(LOGOUT_EVENT, () => {
+    clearUser();
+    state.initialized = true; // 이후 guard에서 재시도 무한루프 방지
+  });
 }
 
 /**
@@ -33,6 +63,9 @@ async function login(credentials) {
   try {
     const user = await authService.login(credentials);
     setUser(user);
+
+    state.initialized = true;
+
     return user;
   } catch (err) {
     const message =
@@ -60,7 +93,8 @@ async function fetchCurrentUser({ force = false } = {}) {
 
   try {
     const user = await authService.fetchCurrentUser();
-    setUser(user);
+    if (user) setUser(user);
+    else clearUser();
   } catch (err) {
     console.error("[authStore] fetchCurrentUser error:", err);
     clearUser();
@@ -83,6 +117,7 @@ async function logout() {
     console.error("[authStore] logout error:", err);
   } finally {
     clearUser();
+    state.initialized = true;
     state.isLoading = false;
   }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -164,6 +164,16 @@ router.beforeEach(async (to, from, next) => {
     try {
       group = await fetchGroupById(groupId, { requesterId: uid });
     } catch (e) {
+      if (e?.response?.status === 401) {
+        window.alert("로그인이 필요합니다.");
+
+        return next({
+          name: "Login",
+          query: { redirect: to.fullPath },
+          replace: true,
+        });
+      }
+
       console.error("[router] fetchGroupById error:", e);
       window.alert("그룹 정보를 불러올 수 없습니다.");
       return next({ name: "GroupList" });

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -33,6 +33,8 @@ import {
   mockCheckBaekjoonId,
 } from "@/mocks/auth.mock";
 
+import { USER_STORAGE_KEY } from "../constants/auth";
+
 const USE_MOCK_AUTH = apiMode.auth === "mock";
 
 function toFrontendUser(u) {
@@ -46,8 +48,6 @@ function toFrontendUser(u) {
     updatedAt: u.updatedAt,
   };
 }
-
-const USER_STORAGE_KEY = "bsm_user";
 
 export const authService = {
   /**

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -47,6 +47,8 @@ function toFrontendUser(u) {
   };
 }
 
+const USER_STORAGE_KEY = "bsm_user";
+
 export const authService = {
   /**
    * 로그인
@@ -77,12 +79,20 @@ export const authService = {
       return mockGetCurrentUser();
     }
 
-    // TODO: 백엔드에서 /members/me 준비되면 아래 구현
-    // const me = await getMyProfile();
-    // return me;
-    throw new Error(
-      "authService.fetchCurrentUser: not implemented for real API yet",
-    );
+    if (typeof window === "undefined") return null;
+
+    try {
+      const raw = window.localStorage.getItem(USER_STORAGE_KEY);
+      if (!raw) return null;
+
+      const user = JSON.parse(raw);
+      if (!user || typeof user.id !== "number") return null;
+
+      return user;
+    } catch (e) {
+      console.warn("[authService] fetchCurrentUser: parse failed:", e);
+      return null;
+    }
   },
 
   /**

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -46,7 +46,10 @@ async function handleSubmit() {
       password: password.value,
     });
 
-    router.push({ name: "GroupList" });
+    const redirect =
+      (route.query.redirect && String(route.query.redirect)) || null;
+
+    router.replace(redirect || { name: "GroupList" });
   } catch (e) {
     // authStore.error에 백엔드/목 기준 메시지가 들어있도록 설계해둠
     errorMessage.value =

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -49,7 +49,9 @@ async function handleSubmit() {
     const redirect =
       (route.query.redirect && String(route.query.redirect)) || null;
 
-    router.replace(redirect || { name: "GroupList" });
+    const isValidRedirect =
+      redirect && redirect.startsWith("/") && !redirect.startsWith("//");
+    router.replace(isValidRedirect ? redirect : { name: "GroupList" });
   } catch (e) {
     // authStore.error에 백엔드/목 기준 메시지가 들어있도록 설계해둠
     errorMessage.value =

--- a/tests/LoginView.spec.js
+++ b/tests/LoginView.spec.js
@@ -6,14 +6,15 @@ import { ref } from "vue";
 // 1) vue-router mock
 // =======================
 const pushMock = vi.fn();
+const replaceMock = vi.fn();
+const routeMock = { query: {} };
 
 vi.mock("vue-router", () => ({
   useRouter: () => ({
     push: pushMock,
+    replace: replaceMock,
   }),
-  useRoute: () => ({
-    query: {}, // 기본값: 쿼리 없음
-  }),
+  useRoute: () => routeMock,
 }));
 
 // =======================
@@ -57,6 +58,8 @@ describe("LoginView", () => {
 
     // mock & 상태 초기화
     pushMock.mockReset();
+    replaceMock.mockReset();
+    routeMock.query = {};
     authStore.login.mockReset();
     authStore.resetError.mockReset();
 
@@ -75,9 +78,31 @@ describe("LoginView", () => {
     expect(authStore.login).not.toHaveBeenCalled();
   });
 
-  it("유효한 입력 시 authStore.login을 호출하고 GroupList로 이동한다", async () => {
-    // ✅ 로그인 성공 시나리오
+  it("유효한 입력 시 authStore.login을 호출하고 기본으로 GroupList로 이동한다", async () => {
     authStore.login.mockResolvedValue();
+
+    routeMock.query = {};
+
+    const wrapper = mount(LoginView);
+
+    await wrapper.find("#email").setValue("test@example.com");
+    await wrapper.find("#password").setValue("password123");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(authStore.login).toHaveBeenCalledWith({
+      email: "test@example.com",
+      password: "password123",
+    });
+
+    expect(replaceMock).toHaveBeenCalledWith({ name: "GroupList" });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("redirect 쿼리가 있으면 로그인 후 해당 경로로 이동한다", async () => {
+    authStore.login.mockResolvedValue();
+
+    routeMock.query = { redirect: "/me" };
 
     const wrapper = mount(LoginView);
 
@@ -92,7 +117,8 @@ describe("LoginView", () => {
       password: "password123",
     });
 
-    expect(pushMock).toHaveBeenCalledWith({ name: "GroupList" });
+    expect(replaceMock).toHaveBeenCalledWith("/me");
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("로그인 실패 시 에러 메시지를 보여준다", async () => {


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/62
---
## ✅ 구현 내용

* 새로고침 시 로그인 상태가 유지되도록 accessToken/user를 localStorage에 저장 및 복구(hydration)하도록 개선했습니다.
* refreshToken이 없는 현재 구조에 맞게, **401(만료/무효) 발생 시 세션(token/user)을 정리**해 비로그인 상태가 즉시 반영되도록 했습니다.
* LoginView에서 guard가 넘긴 `redirect` 쿼리를 처리하여, 로그인 성공 후 **원래 가려던 경로로 이동**하도록 개선했습니다.
* LoginView 테스트에서 vue-router mock을 올바르게 수정하고, **redirect 케이스 테스트를 추가**했습니다.

---

## 📂 변경 모듈

* `httpClient.js`

  * accessToken localStorage 저장/복구
  * 401 처리 시 token/user 정리
* `authStore.js`

  * user localStorage 저장/복구
  * 401 로그아웃 이벤트/정리 흐름 반영
* `authService.js`

  * real 모드 `fetchCurrentUser()`를 localStorage 기반 복구로 구현(백엔드 /me 부재 대응)
* `router/index.js`

  * 그룹 권한 체크 중 401이면 Login redirect
* `LoginView.vue`

  * 로그인 성공 시 `redirect` 우선 이동, 없으면 GroupList 이동 (replace)
* `LoginView.spec.js`

  * `useRoute` mock 수정 (`useRoute: () => routeMock`)
  * 기본 이동/redirect 이동 테스트 추가

---

## 🧪 시나리오

* [x] 로그인 성공 → GroupList 이동(redirect 없을 때)
* [x] 로그인 성공 → redirect(`/me`)로 이동
* [x] 새로고침 → localStorage에서 user/token 복구 → 로그인 유지
* [x] 권한 체크 API 중 401 → Login으로 redirect
* [x] LoginView unit tests 통과

---

## 💡 기타

* 현재 백엔드에서 refreshToken 및 `/members/me`가 없어서 프론트에서 localStorage 복구로 UX를 보장합니다.
* 추후 백엔드 지원 시 `/members/me` + refresh 흐름으로 전환 가능하도록 구조를 유지했습니다.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 로그인 세션이 페이지 새로고침 후에도 유지됩니다.
  * 로그인 후 이전에 접속하던 페이지로 자동 리디렉션됩니다.

* **버그 수정**
  * 비인증 요청 오류 처리가 개선되어 로그인 화면으로 안내됩니다.
  * 로그아웃 시 모든 세션 정보가 완벽하게 제거됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->