### PR TITLE
[BSM-64] feat: GroupList card-click navigation and overflow menu actions

### DIFF
--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -57,10 +57,30 @@ function handleResize() {
   if (actionMenuGroupId.value) closeActionMenu();
 }
 
-onMounted(() => {
+function handleEditClick(groupId) {
+  closeActionMenu();
+  goEditGroup(groupId);
+}
+
+function handleLeaveClick(groupId) {
+  closeActionMenu();
+  handleLeaveGroup(groupId);
+}
+
+onMounted(async () => {
   document.addEventListener("click", closeActionMenu);
   window.addEventListener("resize", handleResize);
-  window.addEventListener("scroll", closeActionMenu, true); // 스크롤 시 닫기(겹침 방지)
+  window.addEventListener("scroll", closeActionMenu, true);
+
+  const uid = currentUserId.value;
+  if (!uid) {
+    console.warn(
+      "[GroupList] currentUserId가 없어 그룹 목록을 불러오지 않습니다.",
+    );
+    window.alert("로그인이 필요합니다.");
+    return;
+  }
+  await fetchGroups({ requesterId: uid });
 });
 
 onUnmounted(() => {
@@ -72,19 +92,6 @@ onUnmounted(() => {
 const searchQuery = ref("");
 
 const currentUserId = computed(() => authStore.user.value?.id ?? null);
-
-onMounted(async () => {
-  const uid = currentUserId.value;
-  if (!uid) {
-    console.warn(
-      "[GroupList] currentUserId가 없어 그룹 목록을 불러오지 않습니다.",
-    );
-    window.alert("로그인이 필요합니다.");
-    return;
-  }
-
-  await fetchGroups({ requesterId: uid });
-});
 
 function isOwner(group) {
   if (!group) return false;
@@ -418,12 +425,7 @@ const filteredGroups = computed(() => {
                 type="button"
                 class="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                 role="menuitem"
-                @click.stop="
-                  () => {
-                    closeActionMenu();
-                    goEditGroup(group.id);
-                  }
-                "
+                @click.stop="handleEditClick(group.id)"
               >
                 ✏️ 수정
               </button>
@@ -443,12 +445,7 @@ const filteredGroups = computed(() => {
                     ? '소유자는 바로 탈퇴할 수 없습니다. 소유자 변경 후 탈퇴하세요.'
                     : ''
                 "
-                @click.stop="
-                  () => {
-                    closeActionMenu();
-                    handleLeaveGroup(group.id);
-                  }
-                "
+                @click.stop="handleLeaveClick(group.id)"
               >
                 <span v-if="leavingGroupId === group.id">⏳ 탈퇴 중...</span>
                 <span v-else-if="isOwner(group)">🚫 탈퇴 불가</span>

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -428,7 +428,10 @@ const filteredGroups = computed(() => {
                 ✏️ 수정
               </button>
 
-              <div class="h-px bg-gray-100" />
+              <div
+                v-if="canEditGroup(group)"
+                class="h-px bg-gray-100"
+              />
 
               <button
                 type="button"

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, onUnmounted, computed, nextTick } from "vue";
 import { useRouter } from "vue-router";
 import { groups, fetchGroups, leaveGroup } from "../../data/groupStore";
 import { useAuthStore } from "../../data/authStore";
@@ -8,6 +8,66 @@ const router = useRouter();
 const authStore = useAuthStore();
 
 const leavingGroupId = ref(null);
+
+const actionMenuGroupId = ref(null);
+const menuPlacement = ref("bottom"); // "bottom" | "top"
+const menuRef = ref(null);
+
+function getMenuEl() {
+  const v = menuRef.value;
+  return Array.isArray(v) ? v[0] : v; // v-for ref 대응
+}
+
+async function toggleActionMenu(groupId, e) {
+  if (actionMenuGroupId.value === groupId) {
+    closeActionMenu();
+    return;
+  }
+
+  actionMenuGroupId.value = groupId;
+
+  await nextTick();
+  computeMenuPlacement(e);
+}
+
+function computeMenuPlacement(e) {
+  const menuEl = getMenuEl();
+  const anchorEl = e?.currentTarget;
+  if (!menuEl || !anchorEl) return;
+
+  const a = anchorEl.getBoundingClientRect();
+  const m = menuEl.getBoundingClientRect();
+  const padding = 12;
+
+  const spaceBelow = window.innerHeight - a.bottom;
+  const spaceAbove = a.top;
+
+  // 아래가 부족하면 위로 열기
+  menuPlacement.value =
+    spaceBelow < m.height + padding && spaceAbove > spaceBelow
+      ? "top"
+      : "bottom";
+}
+
+function closeActionMenu() {
+  actionMenuGroupId.value = null;
+}
+
+function handleResize() {
+  if (actionMenuGroupId.value) closeActionMenu();
+}
+
+onMounted(() => {
+  document.addEventListener("click", closeActionMenu);
+  window.addEventListener("resize", handleResize);
+  window.addEventListener("scroll", closeActionMenu, true); // 스크롤 시 닫기(겹침 방지)
+});
+
+onUnmounted(() => {
+  document.removeEventListener("click", closeActionMenu);
+  window.removeEventListener("resize", handleResize);
+  window.removeEventListener("scroll", closeActionMenu, true);
+});
 
 const searchQuery = ref("");
 
@@ -222,115 +282,174 @@ const filteredGroups = computed(() => {
         <li
           v-for="group in filteredGroups"
           :key="group.id"
-          class="group relative flex cursor-pointer flex-col justify-between overflow-hidden rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm transition-all hover:-translate-y-0.5 hover:border-yellow-300 hover:shadow-md"
+          :class="[
+            'group relative overflow-visible transition-all hover:-translate-y-0.5',
+            actionMenuGroupId === group.id ? 'z-50' : 'z-0',
+          ]"
           role="button"
           tabindex="0"
           @click="goGroup(group.id)"
           @keydown.enter="goGroup(group.id)"
           @keydown.space.prevent="goGroup(group.id)"
         >
-          <!-- 상단 색띠 -->
+          <!-- ✅ 카드 본문: 여기만 클리핑 -->
           <div
-            class="pointer-events-none absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r from-yellow-300 via-amber-300 to-orange-300 opacity-0 group-hover:opacity-100 transition-opacity"
-          />
-
-          <div class="flex items-start gap-3">
-            <!-- 이니셜 뱃지 -->
+            class="relative overflow-hidden rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm transition-all group-hover:border-yellow-300 group-hover:shadow-md focus:outline-none focus:ring-2 focus:ring-yellow-200 focus:ring-offset-2"
+          >
+            <!-- 상단 색띠 -->
             <div
-              class="hidden sm:flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-yellow-100 text-sm font-semibold text-yellow-700"
-            >
-              {{ group.name?.charAt(0) || "G" }}
-            </div>
+              class="pointer-events-none absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r from-yellow-300 via-amber-300 to-orange-300 opacity-0 group-hover:opacity-100 transition-opacity"
+            />
 
-            <div class="min-w-0 flex-1">
-              <div class="flex items-center gap-2">
-                <h2
-                  class="truncate text-sm sm:text-base font-semibold text-gray-900"
-                >
-                  {{ group.name }}
-                </h2>
-
-                <svg
-                  class="h-4 w-4 flex-shrink-0 text-gray-300 group-hover:text-yellow-500 transition-colors"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M9 18l6-6-6-6"
-                  />
-                </svg>
+            <div class="flex items-start gap-3 pr-12">
+              <!-- 이니셜 뱃지 -->
+              <div
+                class="hidden sm:flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-yellow-100 text-sm font-semibold text-yellow-700"
+              >
+                {{ group.name?.charAt(0) || "G" }}
               </div>
 
-              <p class="mt-1 line-clamp-2 text-[11px] sm:text-xs text-gray-500">
-                {{ group.description }}
-              </p>
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2">
+                  <h2
+                    class="flex-1 truncate text-sm sm:text-base font-semibold text-gray-900"
+                  >
+                    {{ group.name }}
+                  </h2>
 
-              <p
-                v-if="group.updatedAt"
-                class="mt-1 text-[10px] text-gray-400"
-              >
-                최근 업데이트:
-                {{ group.updatedAt }}
-                <!-- ⚠️ 나중에 dayjs 같은 걸로 예쁘게 포맷팅 가능 -->
-              </p>
+                  <!-- (선택) 카드 클릭 유도 chevron -->
+                  <svg
+                    class="h-4 w-4 flex-shrink-0 text-gray-300 group-hover:text-yellow-500 transition-colors"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 18l6-6-6-6"
+                    />
+                  </svg>
+                </div>
+
+                <p
+                  class="mt-1 line-clamp-2 text-[11px] sm:text-xs text-gray-500"
+                >
+                  {{ group.description }}
+                </p>
+
+                <p
+                  v-if="group.updatedAt"
+                  class="mt-1 text-[10px] text-gray-400"
+                >
+                  최근 업데이트: {{ group.updatedAt }}
+                </p>
+              </div>
+            </div>
+
+            <div class="mt-3 flex items-center justify-between text-[11px]">
+              <div class="flex items-center gap-2 text-gray-400">
+                <span
+                  class="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500 border border-gray-100"
+                >
+                  👥 멤버 {{ group.memberCount }}명
+                </span>
+
+                <span
+                  v-if="isOwner(group)"
+                  class="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-800 border border-yellow-200"
+                >
+                  ⭐ 내 소유 그룹
+                </span>
+
+                <span
+                  v-else-if="isManager(group)"
+                  class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700 border border-blue-100"
+                >
+                  🛠 매니저
+                </span>
+              </div>
             </div>
           </div>
 
-          <div class="mt-3 flex items-center justify-between text-[11px]">
-            <div class="flex items-center gap-2 text-gray-400">
-              <span
-                class="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500 border border-gray-100"
+          <!-- ✅ 더보기 액션: 클리핑 밖(안 잘림) -->
+          <div
+            class="absolute right-3 top-3 z-50"
+            @click.stop
+          >
+            <button
+              type="button"
+              class="inline-flex items-center justify-center h-9 w-9 rounded-lg border border-gray-200 bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-200"
+              aria-label="그룹 액션 메뉴"
+              aria-haspopup="menu"
+              :aria-expanded="actionMenuGroupId === group.id"
+              @click.stop="toggleActionMenu(group.id, $event)"
+              @keydown.esc.stop="closeActionMenu"
+            >
+              <svg
+                class="w-5 h-5"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
               >
-                👥 멤버 {{ group.memberCount }}명
-              </span>
+                <path
+                  d="M12 7a2 2 0 1 0-0.001-4.001A2 2 0 0 0 12 7Zm0 7a2 2 0 1 0-0.001-4.001A2 2 0 0 0 12 14Zm0 7a2 2 0 1 0-0.001-4.001A2 2 0 0 0 12 21Z"
+                />
+              </svg>
+            </button>
 
-              <span
-                v-if="isOwner(group)"
-                class="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-800 border border-yellow-200"
-              >
-                ⭐ 내 소유 그룹
-              </span>
-
-              <span
-                v-else-if="isManager(group)"
-                class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700 border border-blue-100"
-              >
-                🛠 매니저
-              </span>
-            </div>
-
-            <div class="flex items-center gap-1">
-              <!-- 그룹 수정 -->
+            <div
+              v-if="actionMenuGroupId === group.id"
+              ref="menuRef"
+              :class="[
+                'absolute right-0 z-50 w-44 max-w-[calc(100vw-16px)] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg',
+                menuPlacement === 'top' ? 'bottom-full mb-2' : 'top-full mt-2',
+              ]"
+              role="menu"
+              @click.stop
+              @keydown.esc.stop="closeActionMenu"
+            >
               <button
                 v-if="canEditGroup(group)"
                 type="button"
-                class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 bg-white text-gray-500 hover:text-gray-700 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-200"
-                @click.stop="goEditGroup(group.id)"
+                class="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                role="menuitem"
+                @click.stop="
+                  () => {
+                    closeActionMenu();
+                    goEditGroup(group.id);
+                  }
+                "
               >
-                수정
+                ✏️ 수정
               </button>
 
-              <!-- 그룹 탈퇴 -->
+              <div class="h-px bg-gray-100" />
+
               <button
                 type="button"
-                class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-200 bg-red-50 text-red-600 hover:bg-red-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-red-200"
+                class="w-full px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                role="menuitem"
                 :disabled="leavingGroupId === group.id || isOwner(group)"
                 :title="
                   isOwner(group)
-                    ? '소유자는 바로 탈퇴할 수 없습니다. 그룹 수정에서 소유자 변경 후 탈퇴하세요.'
+                    ? '소유자는 바로 탈퇴할 수 없습니다. 소유자 변경 후 탈퇴하세요.'
                     : ''
                 "
-                @click.stop="handleLeaveGroup(group.id)"
+                @click.stop="
+                  () => {
+                    closeActionMenu();
+                    handleLeaveGroup(group.id);
+                  }
+                "
               >
-                <span v-if="leavingGroupId === group.id">탈퇴 중...</span>
-                <span v-else-if="isOwner(group)">탈퇴 불가</span>
-                <span v-else>그룹 탈퇴</span>
+                <span v-if="leavingGroupId === group.id">⏳ 탈퇴 중...</span>
+                <span v-else-if="isOwner(group)">🚫 탈퇴 불가</span>
+                <span v-else>🚪 그룹 탈퇴</span>
               </button>
             </div>
           </div>

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -223,6 +223,11 @@ const filteredGroups = computed(() => {
           v-for="group in filteredGroups"
           :key="group.id"
           class="group relative flex cursor-pointer flex-col justify-between overflow-hidden rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm transition-all hover:-translate-y-0.5 hover:border-yellow-300 hover:shadow-md"
+          role="button"
+          tabindex="0"
+          @click="goGroup(group.id)"
+          @keydown.enter="goGroup(group.id)"
+          @keydown.space.prevent="goGroup(group.id)"
         >
           <!-- 상단 색띠 -->
           <div
@@ -244,6 +249,22 @@ const filteredGroups = computed(() => {
                 >
                   {{ group.name }}
                 </h2>
+
+                <svg
+                  class="h-4 w-4 flex-shrink-0 text-gray-300 group-hover:text-yellow-500 transition-colors"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 18l6-6-6-6"
+                  />
+                </svg>
               </div>
 
               <p class="mt-1 line-clamp-2 text-[11px] sm:text-xs text-gray-500">
@@ -285,33 +306,31 @@ const filteredGroups = computed(() => {
             </div>
 
             <div class="flex items-center gap-1">
-              <!-- 그룹 입장 -->
+              <!-- 그룹 수정 -->
               <button
+                v-if="canEditGroup(group)"
                 type="button"
-                class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-yellow-400 bg-yellow-50 text-yellow-700 hover:bg-yellow-100 transition-colors"
-                @click="goGroup(group.id)"
+                class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 bg-white text-gray-500 hover:text-gray-700 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-200"
+                @click.stop="goEditGroup(group.id)"
               >
-                그룹 들어가기
+                수정
               </button>
 
               <!-- 그룹 탈퇴 -->
               <button
                 type="button"
-                class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-400 bg-red-50 text-red-600 hover:bg-red-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                :disabled="leavingGroupId === group.id"
-                @click="handleLeaveGroup(group.id)"
+                class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-200 bg-red-50 text-red-600 hover:bg-red-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-red-200"
+                :disabled="leavingGroupId === group.id || isOwner(group)"
+                :title="
+                  isOwner(group)
+                    ? '소유자는 바로 탈퇴할 수 없습니다. 그룹 수정에서 소유자 변경 후 탈퇴하세요.'
+                    : ''
+                "
+                @click.stop="handleLeaveGroup(group.id)"
               >
-                {{ leavingGroupId === group.id ? "탈퇴 중..." : "그룹 탈퇴" }}
-              </button>
-
-              <!-- 그룹 수정 -->
-              <button
-                v-if="canEditGroup(group)"
-                type="button"
-                class="px-3 py-1.5 text-xs font-medium border rounded-lg bg-white text-gray-700 hover:bg-gray-50"
-                @click.stop="goEditGroup(group.id)"
-              >
-                수정
+                <span v-if="leavingGroupId === group.id">탈퇴 중...</span>
+                <span v-else-if="isOwner(group)">탈퇴 불가</span>
+                <span v-else>그룹 탈퇴</span>
               </button>
             </div>
           </div>

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -257,9 +257,6 @@ describe("GroupList.vue", () => {
     await menuBtn.trigger("click");
     await flushPromises();
 
-    expect(pushMock).not.toHaveBeenCalledWith({
-      name: "BoardList",
-      params: { groupId: 3 },
-    });
+    expect(pushMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -245,4 +245,21 @@ describe("GroupList.vue", () => {
       params: { groupId: 3 },
     });
   });
+
+  it("액션 메뉴 버튼 클릭 시 BoardList로 이동하지 않는다", async () => {
+    const wrapper = mount(GroupList);
+    await flushPromises();
+    await nextTick();
+
+    const item = findGroupItemByName(wrapper, "내가 member만인 그룹");
+    const menuBtn = item.find('button[aria-label="그룹 액션 메뉴"]');
+
+    await menuBtn.trigger("click");
+    await flushPromises();
+
+    expect(pushMock).not.toHaveBeenCalledWith({
+      name: "BoardList",
+      params: { groupId: 3 },
+    });
+  });
 });

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -59,6 +59,15 @@ function findButton(item, label) {
   return item.findAll("button").find((btn) => btn.text().includes(label));
 }
 
+async function openActionMenu(item) {
+  const menuBtn = item.find('button[aria-label="그룹 액션 메뉴"]');
+  expect(menuBtn.exists(), "⋯(액션 메뉴) 버튼을 찾지 못했습니다").toBe(true);
+
+  await menuBtn.trigger("click");
+  await flushPromises();
+  await nextTick();
+}
+
 describe("GroupList.vue", () => {
   beforeEach(() => {
     // 유저(1)가 owner / manager / member 인 그룹 + 완전 관계없는 그룹
@@ -121,7 +130,7 @@ describe("GroupList.vue", () => {
     expect(text).toContain("내가 member만인 그룹");
   });
 
-  it("OWNER/MANAGER 그룹에는 '수정' 버튼이 보이고, MEMBER 그룹에는 보이지 않는다 (groupRole 기준)", async () => {
+  it("OWNER/MANAGER 그룹에는 '수정' 메뉴가 보이고, MEMBER 그룹에는 보이지 않는다 (groupRole 기준)", async () => {
     const wrapper = mount(GroupList);
     await flushPromises();
     await nextTick();
@@ -130,12 +139,17 @@ describe("GroupList.vue", () => {
     const managerItem = findGroupItemByName(wrapper, "내가 manager인 그룹");
     const memberItem = findGroupItemByName(wrapper, "내가 member만인 그룹");
 
-    expect(ownerItem, "owner 그룹 li를 찾지 못했습니다").toBeTruthy();
-    expect(managerItem, "manager 그룹 li를 찾지 못했습니다").toBeTruthy();
-    expect(memberItem, "member 그룹 li를 찾지 못했습니다").toBeTruthy();
+    expect(ownerItem).toBeTruthy();
+    expect(managerItem).toBeTruthy();
+    expect(memberItem).toBeTruthy();
 
+    await openActionMenu(ownerItem);
     expect(hasButton(ownerItem, "수정")).toBe(true);
+
+    await openActionMenu(managerItem);
     expect(hasButton(managerItem, "수정")).toBe(true);
+
+    await openActionMenu(memberItem);
     expect(hasButton(memberItem, "수정")).toBe(false);
   });
 
@@ -147,8 +161,10 @@ describe("GroupList.vue", () => {
     const managerItem = findGroupItemByName(wrapper, "내가 manager인 그룹");
     expect(managerItem).toBeTruthy();
 
+    await openActionMenu(managerItem);
+
     const editBtn = findButton(managerItem, "수정");
-    expect(editBtn, "'수정' 버튼을 찾지 못했습니다").toBeTruthy();
+    expect(editBtn, "'수정' 메뉴를 찾지 못했습니다").toBeTruthy();
 
     await editBtn.trigger("click");
     await flushPromises();
@@ -161,7 +177,7 @@ describe("GroupList.vue", () => {
     });
   });
 
-  it("OWNER는 '그룹 탈퇴' 클릭 시 차단되고 leaveGroup이 호출되지 않는다", async () => {
+  it("OWNER는 '탈퇴 불가'로 표시되고 leaveGroup이 호출되지 않는다", async () => {
     const confirmSpy = vi.spyOn(window, "confirm");
     const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
 
@@ -172,15 +188,16 @@ describe("GroupList.vue", () => {
     const ownerItem = findGroupItemByName(wrapper, "내가 owner인 그룹");
     expect(ownerItem).toBeTruthy();
 
-    const leaveBtn = findButton(ownerItem, "그룹 탈퇴");
-    expect(leaveBtn, "'그룹 탈퇴' 버튼을 찾지 못했습니다").toBeTruthy();
+    await openActionMenu(ownerItem);
 
-    await leaveBtn.trigger("click");
-    await flushPromises();
-    await nextTick();
+    const leaveBtn = findButton(ownerItem, "탈퇴 불가");
+    expect(leaveBtn, "'탈퇴 불가' 버튼을 찾지 못했습니다").toBeTruthy();
 
-    expect(alertSpy).toHaveBeenCalled(); // 차단 안내
-    expect(confirmSpy).not.toHaveBeenCalled(); // confirm까지 가지 않음
+    // disabled라서 클릭 자체가 안 되는 게 정상
+    expect(leaveBtn.element.disabled).toBe(true);
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
     expect(leaveGroupMock).not.toHaveBeenCalled();
 
     confirmSpy.mockRestore();
@@ -198,16 +215,34 @@ describe("GroupList.vue", () => {
     const memberItem = findGroupItemByName(wrapper, "내가 member만인 그룹");
     expect(memberItem).toBeTruthy();
 
+    await openActionMenu(memberItem);
+
     const leaveBtn = findButton(memberItem, "그룹 탈퇴");
-    expect(leaveBtn, "'그룹 탈퇴' 버튼을 찾지 못했습니다").toBeTruthy();
+    expect(leaveBtn, "'그룹 탈퇴' 메뉴를 찾지 못했습니다").toBeTruthy();
 
     await leaveBtn.trigger("click");
     await flushPromises();
     await nextTick();
 
+    expect(confirmSpy).toHaveBeenCalled();
     expect(leaveGroupMock).toHaveBeenCalledWith(3, { requesterId: 1 });
 
     confirmSpy.mockRestore();
     alertSpy.mockRestore();
+  });
+
+  it("그룹 카드를 클릭하면 BoardList로 이동한다", async () => {
+    const wrapper = mount(GroupList);
+    await flushPromises();
+    await nextTick();
+
+    const item = findGroupItemByName(wrapper, "내가 member만인 그룹");
+    expect(item).toBeTruthy();
+
+    await item.trigger("click");
+    expect(pushMock).toHaveBeenCalledWith({
+      name: "BoardList",
+      params: { groupId: 3 },
+    });
   });
 });


### PR DESCRIPTION
이슈 번호 : https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/64 
---
## ✅ 구현 내용

* 그룹 입장을 “그룹 들어가기” 버튼 클릭에서 **카드 클릭**으로 변경
* “그룹 들어가기” 버튼 제거 (CTA 단순화)
* **수정/탈퇴**를 `⋯` 더보기 메뉴로 이동
* Owner의 경우 “탈퇴 불가”를 **disabled UI**로 표시
* 좁은 화면/그리드에서도 메뉴가 잘리지 않도록 개선

  * 클리핑(rounded) 유지하면서 메뉴가 카드 밖으로 표시되도록 구조 분리
  * stacking(z-index) 이슈로 인한 가림 현상 보정
  * 메뉴 위치 위/아래 자동 플립 적용
  * 스크롤/리사이즈/바깥 클릭 시 메뉴 닫기

## 📂 변경 모듈

* `src/components/group/GroupList.vue`
* `test/GroupList.spec.js`

## 🧪 시나리오

* [x] 그룹 카드를 클릭하면 BoardList로 이동한다
* [x] `⋯` 클릭 시 메뉴가 열리고, 카드 클릭 이동이 발생하지 않는다
* [x] “수정” 클릭 시 GroupEdit로 이동한다
* [x] “탈퇴” 클릭 시 confirm 후 탈퇴 처리된다 (owner는 탈퇴 불가)
* [x] 브라우저 가로폭을 줄여도 메뉴가 잘리거나 다른 카드에 가려지지 않는다

## 💡 기타

* 키보드 접근성: Enter/Space로 입장, ESC로 메뉴 닫기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 각 그룹 카드에 컨텍스트 액션 메뉴 추가(편집·탈퇴 등), 버튼으로 토글 가능하고 뷰포트에 따라 위/아래로 자동 배치
  * 카드 헤더 정보 확장(업데이트 시간·회원 수·소유자/관리자 표시) 및 키보드 접근성 개선(ARIA, 포커스 관리)

* **버그 수정**
  * 메뉴 열림/닫힘 충돌 방지(클릭·리사이즈·스크롤 핸들링 개선)

* **테스트**
  * 메뉴 기반 상호작용으로 테스트 업데이트(메뉴 오픈 후 항목 검증, 소유자 탈퇴 비활성화, 회원 탈퇴 흐름, 카드 클릭 네비게이션 검증)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->