### PR TITLE
[BSM-67] feat: support option query and enforce exclusive toggles

### DIFF
--- a/src/api/problemApi.js
+++ b/src/api/problemApi.js
@@ -33,6 +33,7 @@ export async function searchByNumber(problemNo) {
  *   tags?: string[],
  *   minSolvers?: number,
  *   unsolved?: boolean
+ *   option?: 0 | 1 | 2
  * }} params
  * @returns {Promise<Array>} problems
  */
@@ -45,6 +46,7 @@ export async function filterProblems({
   tags,
   minSolvers,
   unsolved,
+  option,
 } = {}) {
   if (!groupId) {
     throw new Error(
@@ -61,6 +63,7 @@ export async function filterProblems({
     unsolved,
     problemIds,
     tags,
+    option,
   };
 
   // explode=true: ?tags=a&tags=b&problemIds=1&problemIds=2

--- a/src/components/ProblemSearch.vue
+++ b/src/components/ProblemSearch.vue
@@ -21,16 +21,6 @@ const loading = ref(false);
 const error = ref("");
 const results = ref([]);
 
-// 배열에서 랜덤으로 최대 count개 추출
-function getRandomSubset(arr, count) {
-  const copy = [...arr];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [copy[i], copy[j]] = [copy[j], copy[i]];
-  }
-  return copy.slice(0, count);
-}
-
 // 🔍 필터 컴포넌트에서 'search' 이벤트를 받았을 때 실행
 async function handleFiltersSearch(filter) {
   loading.value = true;
@@ -73,8 +63,19 @@ async function handleFiltersSearch(filter) {
       // UI 날짜 필터 (service가 updatedAt->registeredAt 정규화 후 필터까지 처리)
       registeredBefore: filter.registeredBefore || undefined,
 
-      // 확장용 (현재 서버 미지원이어도 payload로 넘겨도 무방)
+      // swagger option: 0 전체 / 1 랜덤5 / 2 AI추천
+      option:
+        filter.mode === "review"
+          ? 0
+          : filter.aiRecommend
+            ? 2
+            : filter.randomMode
+              ? 1
+              : 0,
+
+      // 호환/확장용(서비스가 option 유도할 수도 있어서 같이 넘겨둠)
       aiRecommend: !!filter.aiRecommend,
+      randomMode: !!filter.randomMode,
     };
 
     let baseResults = await problemService.filterProblems(payload);
@@ -99,11 +100,8 @@ async function handleFiltersSearch(filter) {
         });
       }
     } else {
-      if (filter.aiRecommend) {
-        // AI 추천: 서버 순서 그대로 (추후 서버가 지원하면 그대로 UX 유지)
-      } else if (filter.randomMode) {
-        const count = Math.min(5, baseResults.length);
-        baseResults = count > 0 ? getRandomSubset(baseResults, count) : [];
+      if (filter.aiRecommend || filter.randomMode) {
+        // option=2(AI) / option=1(랜덤5): 서버 순서 그대로
       } else {
         // 기본 정렬: reviewCount(낮은 순) -> registeredAt(오래된 순)
         baseResults.sort((a, b) => {

--- a/src/components/search/SearchFilters.vue
+++ b/src/components/search/SearchFilters.vue
@@ -1,6 +1,6 @@
 <!-- src/component/search/SearchFilters.vue -->
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { tags } from "/src/data/tags";
 import { difficultyOptions } from "/src/data/difficultyOptions";
 
@@ -58,6 +58,21 @@ const unsolvedOnly = ref(false);
 
 // AI 추천 모드
 const aiRecommend = ref(false);
+
+watch(randomMode, (v) => {
+  if (v) aiRecommend.value = false;
+});
+
+watch(aiRecommend, (v) => {
+  if (v) randomMode.value = false;
+});
+
+watch(mode, (m) => {
+  if (m === "review") {
+    randomMode.value = false;
+    aiRecommend.value = false;
+  }
+});
 
 // 조건 접기 / 펼치기
 const isFilterCollapsed = ref(false);
@@ -588,12 +603,7 @@ function emitReset() {
                 ? 'border-indigo-400 text-indigo-600'
                 : 'border-gray-300 text-gray-500'
             "
-            @click="
-              aiRecommend = !aiRecommend;
-              if (aiRecommend) {
-                randomMode = false;
-              }
-            "
+            @click="aiRecommend = !aiRecommend"
           >
             <span class="relative inline-flex items-center">
               <span

--- a/src/components/search/SearchFilters.vue
+++ b/src/components/search/SearchFilters.vue
@@ -569,7 +569,10 @@ function emitReset() {
       <div
         class="flex flex-wrap items-center justify-between gap-3 pt-2 border-t border-gray-200"
       >
-        <div class="flex gap-2">
+        <div
+          v-if="mode !== 'review'"
+          class="flex gap-2"
+        >
           <!-- 랜덤 5개 토글 -->
           <button
             type="button"
@@ -620,7 +623,7 @@ function emitReset() {
         </div>
 
         <!-- 검색 / 초기화 -->
-        <div class="flex gap-2">
+        <div class="flex gap-2 ml-auto">
           <button
             type="button"
             class="px-3 py-2 rounded-lg text-xs font-semibold border border-gray-300 text-gray-600 bg-white hover:bg-gray-50"

--- a/src/services/problemService.js
+++ b/src/services/problemService.js
@@ -87,6 +87,20 @@ function normalizeProblem(p) {
   };
 }
 
+function normalizeOption(v) {
+  const n = typeof v === "string" ? Number(v) : v;
+  return Number.isInteger(n) && [0, 1, 2].includes(n) ? n : undefined;
+}
+
+function getRandomSubset(arr, count) {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, count);
+}
+
 export const problemService = {
   /**
    * 문제 번호로 검색 (mock/real 공통 인터페이스)
@@ -136,7 +150,9 @@ export const problemService = {
 
       registeredBefore, // YYYY-MM-DD (클라 후처리)
       beforeDate, // 호환
-      aiRecommend, // 현재 미사용(확장용)
+      aiRecommend, // option=2로 매핑 가능
+      randomMode, // option=1로 매핑 가능
+      option, // 0|1|2 (swagger)
     } = params;
 
     const normalizedMode = mode === "review" ? "review" : "normal"; // general/undefined -> normal
@@ -168,11 +184,19 @@ export const problemService = {
           ? !unsolvedOnly
           : undefined;
 
+    const explicitOption = normalizeOption(option);
+    const derivedOption =
+      normalizedMode === "review" ? 0 : aiRecommend ? 2 : randomMode ? 1 : 0;
+
+    const mergedOption = explicitOption ?? derivedOption;
+
     if (USE_MOCK_PROBLEM) {
       const mockUnsolvedOnly =
         normalizedMode === "normal" && typeof mergedUnsolved === "boolean"
           ? !mergedUnsolved
           : undefined;
+
+      const mockAiRecommend = mergedOption === 2;
 
       // mock은 기존 로직 재활용
       let base = await mockSearchWithConditions({
@@ -182,7 +206,7 @@ export const problemService = {
         minSolved: mergedMinSolvers,
         beforeDate: registeredBefore ?? beforeDate,
         unsolvedOnly: mockUnsolvedOnly, // boolean
-        aiRecommend: !!aiRecommend,
+        aiRecommend: mockAiRecommend,
       });
 
       // tags 후처리 (mockSearchWithConditions는 tag string 기반이라)
@@ -198,6 +222,12 @@ export const problemService = {
       if (Array.isArray(problemIds) && problemIds.length > 0) {
         const set = new Set(problemIds.map(Number));
         base = base.filter((p) => set.has(Number(p.id)));
+      }
+
+      // option=1: 랜덤 5문제 반환 (중복 없음)
+      if (normalizedMode === "normal" && mergedOption === 1) {
+        const count = Math.min(5, base.length);
+        base = count > 0 ? getRandomSubset(base, count) : [];
       }
 
       return base;
@@ -218,6 +248,7 @@ export const problemService = {
       tags: mergedTags,
       minSolvers: mergedMinSolvers,
       unsolved: mergedUnsolved,
+      option: mergedOption,
     });
 
     const normalized = Array.isArray(rawList)

--- a/tests/ProblemSearch.spec.js
+++ b/tests/ProblemSearch.spec.js
@@ -87,6 +87,7 @@ describe("ProblemSearch.vue", () => {
         groupId: 1,
         mode: "general",
         problemIds: [123],
+        option: 0,
       }),
     );
 

--- a/tests/ProblemSearch.spec.js
+++ b/tests/ProblemSearch.spec.js
@@ -230,4 +230,38 @@ describe("ProblemSearch.vue", () => {
     // registeredAt 최신(큰 날짜)이 먼저
     expect(firstId).toBe("20");
   });
+
+  it("randomMode가 true일 때 option: 1을 전달한다", async () => {
+    const spy = vi
+      .spyOn(problemService, "filterProblems")
+      .mockResolvedValue([]);
+
+    const wrapper = mountSubject({ groupId: 1 });
+    emitSearch(wrapper, { mode: "general", randomMode: true });
+    await flushPromises();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        option: 1,
+        randomMode: true,
+      }),
+    );
+  });
+
+  it("aiRecommend가 true일 때 option: 2를 전달한다", async () => {
+    const spy = vi
+      .spyOn(problemService, "filterProblems")
+      .mockResolvedValue([]);
+
+    const wrapper = mountSubject({ groupId: 1 });
+    emitSearch(wrapper, { mode: "general", aiRecommend: true });
+    await flushPromises();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        option: 2,
+        aiRecommend: true,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
이슈 번호 : https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/67
---
### ✅ 구현 내용

* Swagger 스펙의 `option(0/1/2)` 쿼리 파라미터를 FE 전 구간에 반영했습니다.

  * `0: 전체`, `1: 랜덤 5문제`, `2: AI 추천`
* SearchFilters에서 **랜덤/AI 추천 토글을 상호 배타**로 변경했습니다.

  * 랜덤 ON → AI OFF
  * AI ON → 랜덤 OFF
  * review 모드 진입 시 두 옵션 자동 OFF

### 📂 변경 모듈

* `src/api/problemApi.js`

  * `filterProblems`에 `option` 파라미터 추가 및 params 전달
* `src/services/problemService.js`

  * `option` 정규화/유도 로직 추가(0/1/2)
  * mock 모드에서도 `option=1`이면 랜덤 5개 반환(UX 일치)
* `src/components/ProblemSearch.vue`

  * filter → payload 매핑에 `option` 포함
  * option=1/2일 때 서버 순서 유지(클라 랜덤/정렬 개입 최소화)
* `src/component/search/SearchFilters.vue`

  * `watch`로 랜덤/AI 상호 배타 강제 + review 모드에서 옵션 OFF
* `tests/ProblemSearch.spec.js`

  * 서비스 호출 payload에 `option` 값 검증 추가

### 🧪 테스트 시나리오

* [x] 일반 모드 + 랜덤 ON → AI 자동 OFF, 요청 `option=1`
* [x] 일반 모드 + AI ON → 랜덤 자동 OFF, 요청 `option=2`
* [x] review 모드 전환 → 랜덤/AI 자동 OFF, 요청 `option=0`
* [x] ProblemSearch 결과 정렬

  * review 모드: reviewCount 있으면 내림차순, 없으면 registeredAt 최신순
  * normal 모드: option=0일 때만 기존 정렬 적용(그 외는 서버 결과 유지)
* [x] 단위 테스트: `ProblemSearch.spec.js` 통과

### 💡 기타

* 서버가 option=1에서 5개를 보장한다는 전제 하에, UI는 서버 결과를 그대로 사용합니다.
* mock/real 모드 간 UX를 맞추기 위해 mock에서도 option=1 랜덤5를 서비스에서 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문제 필터에 세 가지 옵션(기본/랜덤/AI 추천) 추가

* **개선**
  * 랜덤 모드와 AI 추천 모드의 상호 배제 동작 강화
  * 클라이언트 쪽 무작위 재정렬 제거 — AI/랜덤 모드는 서버 주도 정렬로 일관성 향상
  * 기본 모드의 정렬·필터링 로직 보존 및 정교화

* **테스트**
  * 옵션 관련 동작을 검증하는 테스트 케이스 추가 및 기대값 확장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->