### PR TITLE
[BSM-70] feat: update the board's expiration time

### DIFF
--- a/src/components/BoardList.vue
+++ b/src/components/BoardList.vue
@@ -52,8 +52,6 @@ const searchedBoards = computed(() => {
 const isExpired = (deadline) => {
   if (!deadline) return false; // 마감일 없으면 계속 진행 중
   const today = new Date();
-  // 시간을 00:00:00으로 맞춰 날짜만 비교
-  today.setHours(0, 0, 0, 0);
   return new Date(deadline) < today;
 };
 


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/70
---

## ✅ 구현 내용

* `BoardList`에서 **마감 여부(isExpired)** 판단 로직을 수정했습니다.

  * 기존: “오늘 00:00:00” 기준으로 비교(날짜만 비교)
  * 변경: **현재 시각(now)** 기준으로 비교(시간까지 포함)
* 결과적으로, **마감 시간이 지난 시점부터** 만료 처리됩니다.

---

## 📂 변경 모듈

* `src/components/BoardList.vue`

  * `isExpired()` 내부에서 날짜만 비교하기 위해 사용하던 `today.setHours(0,0,0,0)` 로직 제거

---

## 🧪 시나리오

1. **마감일 없음**

* `deadline = null` → `false` (계속 진행 중)

2. **마감 시간이 아직 남은 경우**

* `deadline = 오늘 23:59` & `now = 오늘 10:00` → `false` (진행 중)

3. **마감 시간이 지난 경우**

* `deadline = 오늘 00:00` & `now = 오늘 10:00` → `true` (만료)

4. **전날 마감**

* `deadline = 어제 23:59` & `now = 오늘` → `true` (만료)

---

## 💡 기타

* 이 변경은 **deadline이 “시간 정보까지 포함된 값(ISO 8601 datetime)”으로 내려온다는 전제**에서 가장 자연스럽게 동작합니다.
  (만약 `YYYY-MM-DD` 같은 “날짜만” 내려오면, JS 파싱/타임존 처리에 따라 의도치 않은 만료 판정이 생길 수 있어요.)
* 후속으로 가능하면:

  * deadline 포맷을 FE/BE에서 명확히 고정(예: `2025-12-23T23:59:59+09:00`)
  * `isExpired`에 대한 단위 테스트 추가(경계값: 00:00, 23:59 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 마감 시간 만료 판단 로직을 개선했습니다. 현재 시각을 정확하게 반영하도록 변경되어 당일 마감 항목의 만료 판정이 더욱 정확해졌습니다. 이제 현재 시간보다 이른 마감은 만료 상태로, 이후 마감은 활성 상태로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->