### PR TITLE
[BSM-74] fix: Show confirmation message and auto-redirect to GroupList after owner change

### DIFF
--- a/src/components/group/GroupEdit.vue
+++ b/src/components/group/GroupEdit.vue
@@ -123,7 +123,7 @@ onMounted(async () => {
   }
 });
 
-+onBeforeUnmount(() => {
+onBeforeUnmount(() => {
   if (ownerChangeTimerId.value !== null) {
     clearTimeout(ownerChangeTimerId.value);
   }

--- a/src/components/group/GroupEdit.vue
+++ b/src/components/group/GroupEdit.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import GroupForm from "./GroupForm.vue";
 import {
@@ -41,6 +41,7 @@ const ownerCandidateId = ref(null);
 const ownerChangeLoading = ref(false);
 const ownerChangeError = ref("");
 const ownerChangeMessage = ref("");
+const ownerChangeTimerId = ref(null);
 
 const currentUserId = computed(() => authStore.user.value?.id ?? null);
 
@@ -122,6 +123,12 @@ onMounted(async () => {
   }
 });
 
++onBeforeUnmount(() => {
+  if (ownerChangeTimerId.value !== null) {
+    clearTimeout(ownerChangeTimerId.value);
+  }
+});
+
 async function handleSubmit(payload) {
   if (submitting.value) return;
 
@@ -199,7 +206,7 @@ async function handleChangeOwner() {
     }
 
     ownerChangeMessage.value = "소유자가 변경되었습니다.";
-    setTimeout(() => {
+    ownerChangeTimerId.value = setTimeout(() => {
       router.push({ name: "GroupList" });
     }, 700);
   } catch (e) {

--- a/src/components/group/GroupEdit.vue
+++ b/src/components/group/GroupEdit.vue
@@ -161,6 +161,12 @@ function handleCancel() {
 }
 
 async function handleChangeOwner() {
+  // 기존 타이머가 있다면 취소
+  if (ownerChangeTimerId.value !== null) {
+    clearTimeout(ownerChangeTimerId.value);
+    ownerChangeTimerId.value = null;
+  }
+
   ownerChangeError.value = "";
   ownerChangeMessage.value = "";
 

--- a/src/components/group/GroupEdit.vue
+++ b/src/components/group/GroupEdit.vue
@@ -199,6 +199,9 @@ async function handleChangeOwner() {
     }
 
     ownerChangeMessage.value = "소유자가 변경되었습니다.";
+    setTimeout(() => {
+      router.push({ name: "GroupList" });
+    }, 700);
   } catch (e) {
     console.error(e);
     ownerChangeError.value =

--- a/tests/GroupEdit.spec.js
+++ b/tests/GroupEdit.spec.js
@@ -1,5 +1,5 @@
 import { mount, flushPromises } from "@vue/test-utils";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import GroupEdit from "../src/components/group/GroupEdit.vue";
 
 // ===== 1) authStore mock =====
@@ -115,6 +115,10 @@ describe("GroupEdit.vue", () => {
     fetchGroupUsers.mockResolvedValue([]);
     routerMock.push.mockReset();
     routerMock.back.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("마운트 시 fetchGroupById 로 그룹 정보를 불러와 initialGroup 으로 전달한다", async () => {
@@ -472,5 +476,108 @@ describe("GroupEdit.vue", () => {
 
     expect(wrapper.text()).toContain("이미 이 멤버가 소유자입니다.");
     expect(changeGroupOwner).not.toHaveBeenCalled();
+  });
+
+  it("새 소유자를 선택하고 '소유자 변경 확정'을 누르면 changeGroupOwner가 호출되고 성공 메시지가 보이며 700ms 후 GroupList로 이동한다", async () => {
+    vi.useFakeTimers();
+
+    fetchGroupById.mockResolvedValue({
+      id: 1,
+      name: "수정용 스터디",
+      description: "",
+      visibility: "PUBLIC",
+      ownerId: 1,
+      managerIds: [1],
+      memberIds: [1, 2],
+    });
+
+    changeGroupOwner.mockResolvedValue({
+      id: 1,
+      name: "수정용 스터디",
+      description: "",
+      visibility: "PUBLIC",
+      ownerId: 2,
+      managerIds: [1],
+      memberIds: [1, 2],
+    });
+
+    const wrapper = mount(GroupEdit);
+    await flushPromises();
+
+    const ownerTab = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("소유자 변경"));
+    await ownerTab.trigger("click");
+    await flushPromises();
+
+    const candidateItem = wrapper
+      .findAll("li")
+      .find((li) => li.text().includes("새소유자"));
+    await candidateItem.trigger("click");
+
+    const confirmBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("소유자 변경 확정"));
+    await confirmBtn.trigger("click");
+    await flushPromises();
+
+    expect(changeGroupOwner).toHaveBeenCalledWith("1", {
+      requesterId: 1,
+      newOwnerId: 2,
+    });
+
+    expect(wrapper.text()).toContain("소유자가 변경되었습니다.");
+    expect(wrapper.text()).toContain("새소유자");
+
+    expect(routerMock.push).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(699);
+    expect(routerMock.push).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(routerMock.push).toHaveBeenCalledTimes(1);
+    expect(routerMock.push).toHaveBeenCalledWith({ name: "GroupList" });
+  });
+
+  it("소유자 변경 실패 시 에러 메시지를 보여주고 700ms가 지나도 GroupList로 이동하지 않는다", async () => {
+    vi.useFakeTimers();
+
+    fetchGroupById.mockResolvedValue({
+      id: 1,
+      name: "수정용 스터디",
+      description: "",
+      visibility: "PUBLIC",
+      ownerId: 1,
+      managerIds: [1],
+      memberIds: [1, 2],
+    });
+
+    changeGroupOwner.mockRejectedValue(new Error("서버 오류"));
+
+    const wrapper = mount(GroupEdit);
+    await flushPromises();
+
+    const ownerTab = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("소유자 변경"));
+    await ownerTab.trigger("click");
+    await flushPromises();
+
+    const candidateItem = wrapper
+      .findAll("li")
+      .find((li) => li.text().includes("새소유자"));
+    await candidateItem.trigger("click");
+
+    const confirmBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("소유자 변경 확정"));
+    await confirmBtn.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("소유자 변경 중 오류가 발생했습니다.");
+    expect(routerMock.push).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(700);
+    expect(routerMock.push).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/74
---
## ✅ 구현 내용
- 그룹 소유자 변경 성공 시 안내 메시지("소유자가 변경되었습니다.")를 노출한 뒤
- 약 700ms 후 GroupList로 자동 이동하도록 UX 흐름 개선

## 📂 변경 모듈
- `src/components/group/GroupEdit.vue`
  - `handleChangeOwner()` 성공 처리에 `setTimeout` 기반 라우팅 추가
- `tests/GroupEdit.spec.js` (또는 실제 경로)
  - 소유자 변경 성공 시 700ms 후 이동 검증 테스트 추가/수정
  - 소유자 변경 실패 시 이동하지 않음을 검증하는 테스트 추가

## 🧪 시나리오
- [x] (성공) 소유자 계정 → 그룹 수정 → `소유자 변경` 탭 → 다른 멤버 선택 → `소유자 변경 확정`
  - 성공 메시지 노출 확인
  - 700ms 후 GroupList로 이동 확인
- [x] (실패) 소유자 변경 API 실패(mock reject)
  - 에러 메시지 노출 확인
  - 700ms가 지나도 페이지 이동이 발생하지 않음 확인

## 💡 기타
- UI 메시지 노출 시간을 700ms로 설정(필요 시 UX 피드백에 따라 조정 가능)
- 기존 권한/검증 로직 및 API 호출 방식은 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 그룹 소유자 변경 후 즉시가 아닌 약 700ms 후에 자동으로 그룹 목록으로 이동하도록 변경되었으며, 컴포넌트가 언마운트될 경우 예정된 이동이 취소됩니다.
* **테스트**
  * 소유자 변경 성공/실패 경로를 검증하는 테스트가 추가되었고, 시간 기반 동작을 제어하기 위한 타이머 사용과 복원이 포함되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->