### PR TITLE
[BSM-76] feat: Restrict Group Edit Permissions to Owners Only

### DIFF
--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -119,7 +119,7 @@ function isManager(group) {
 }
 
 function canEditGroup(group) {
-  return isOwner(group) || isManager(group);
+  return isOwner(group);
 }
 
 function goGroup(groupId) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -209,7 +209,7 @@ router.beforeEach(async (to, from, next) => {
       return next({ name: "GroupList" });
     }
 
-    // 4-2) owner/manager만 접근 가능한 페이지 (GroupEdit, BoardCreate/Edit)
+    // 4-2) owner/manager만 접근 가능한 페이지 (BoardCreate/Edit)
     if (needGroupManager && !(isOwner || isManager)) {
       window.alert("이 그룹의 관리자 또는 소유자만 접근할 수 있습니다.");
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -73,7 +73,7 @@ const routes = [
     name: "GroupEdit",
     component: GroupEdit,
     props: true,
-    meta: { requiresAuth: true, requiresGroupManager: true },
+    meta: { requiresAuth: true, requiresGroupOwner: true },
   },
   {
     path: "/groups/:groupId/boards",
@@ -140,10 +140,11 @@ router.beforeEach(async (to, from, next) => {
   // 4) 그룹 관련 권한 체크
   const needGroupMember = to.meta.requiresGroupMember;
   const needGroupManager = to.meta.requiresGroupManager;
+  const needGroupOwner = to.meta.requiresGroupOwner;
   const groupIdParam = to.params.groupId;
 
-  // groupId가 있고, 멤버/매니저 권한 둘 중 하나라도 필요한 경우에만 검사
-  if (groupIdParam && (needGroupMember || needGroupManager)) {
+  // groupId가 있고, 멤버/매니저/소유자 권한 둘 중 하나라도 필요한 경우에만 검사
+  if (groupIdParam && (needGroupMember || needGroupManager || needGroupOwner)) {
     const groupId = Number(groupIdParam);
 
     if (!Number.isFinite(groupId)) {
@@ -199,6 +200,12 @@ router.beforeEach(async (to, from, next) => {
     // 4-1) 그룹 멤버만 접근 가능한 페이지 (BoardList, BoardDetail 등)
     if (needGroupMember && !isMember) {
       window.alert("이 그룹 멤버만 접근할 수 있는 페이지입니다.");
+      return next({ name: "GroupList" });
+    }
+
+    // 4-1.5) owner만 접근 가능한 페이지 (GroupEdit 등)
+    if (needGroupOwner && !isOwner) {
+      window.alert("이 그룹의 소유자만 접근할 수 있습니다.");
       return next({ name: "GroupList" });
     }
 

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -130,7 +130,7 @@ describe("GroupList.vue", () => {
     expect(text).toContain("내가 member만인 그룹");
   });
 
-  it("OWNER/MANAGER 그룹에는 '수정' 메뉴가 보이고, MEMBER 그룹에는 보이지 않는다 (groupRole 기준)", async () => {
+  it("OWNER 그룹에는 '수정' 메뉴가 보이고, MANAGER/MEMBER 그룹에는 보이지 않는다 (groupRole 기준)", async () => {
     const wrapper = mount(GroupList);
     await flushPromises();
     await nextTick();
@@ -147,23 +147,23 @@ describe("GroupList.vue", () => {
     expect(hasButton(ownerItem, "수정")).toBe(true);
 
     await openActionMenu(managerItem);
-    expect(hasButton(managerItem, "수정")).toBe(true);
+    expect(hasButton(managerItem, "수정")).toBe(false);
 
     await openActionMenu(memberItem);
     expect(hasButton(memberItem, "수정")).toBe(false);
   });
 
-  it("MANAGER가 '수정' 클릭 시 GroupEdit로 이동한다", async () => {
+  it("OWNER가 '수정' 클릭 시 GroupEdit로 이동한다", async () => {
     const wrapper = mount(GroupList);
     await flushPromises();
     await nextTick();
 
-    const managerItem = findGroupItemByName(wrapper, "내가 manager인 그룹");
-    expect(managerItem).toBeTruthy();
+    const ownerItem = findGroupItemByName(wrapper, "내가 owner인 그룹");
+    expect(ownerItem).toBeTruthy();
 
-    await openActionMenu(managerItem);
+    await openActionMenu(ownerItem);
 
-    const editBtn = findButton(managerItem, "수정");
+    const editBtn = findButton(ownerItem, "수정");
     expect(editBtn, "'수정' 메뉴를 찾지 못했습니다").toBeTruthy();
 
     await editBtn.trigger("click");
@@ -173,8 +173,22 @@ describe("GroupList.vue", () => {
     expect(pushMock).toHaveBeenCalledTimes(1);
     expect(pushMock).toHaveBeenCalledWith({
       name: "GroupEdit",
-      params: { groupId: 2 },
+      params: { groupId: 1 },
     });
+  });
+
+  it("MANAGER 그룹에는 '수정'이 없어 GroupEdit로 이동할 수 없다", async () => {
+    const wrapper = mount(GroupList);
+    await flushPromises();
+    await nextTick();
+
+    const managerItem = findGroupItemByName(wrapper, "내가 manager인 그룹");
+    await openActionMenu(managerItem);
+
+    const editBtn = findButton(managerItem, "수정");
+    expect(editBtn).toBeFalsy();
+
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("OWNER는 '탈퇴 불가'로 표시되고 leaveGroup이 호출되지 않는다", async () => {


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/76
---
## Description

그룹 수정 정책이 **OWNER-only**로 변경됨에 따라, 프론트에서 메뉴 노출/라우트 진입/테스트를 정책에 맞게 정합성 있게 업데이트했습니다.
서버에서 이미 권한 강제가 적용되어 있어, 프론트에서는 UX 혼란 및 불필요한 403 경험을 제거하는 데 목적이 있습니다.

---

## ✅ 구현 내용

* GroupList에서 `수정` 메뉴 노출 조건을 **OWNER만 가능**하도록 변경
* 라우터에서 GroupEdit 진입 조건을 **OWNER-only**로 제한 (meta + beforeEach 가드)
* 변경된 정책에 맞게 GroupList 단위 테스트 수정

---

## 📂 변경 모듈

* `src/components/group/GroupList.vue`

  * `canEditGroup()` 정책 변경 (owner-only)
  * 수정 메뉴 노출 로직 반영
* `src/router/index.js`

  * GroupEdit에 owner-only meta 적용 (예: `requiresGroupOwner`)
  * `beforeEach`에서 owner-only 가드 처리 추가
* `GroupList.spec.js`

  * `수정` 메뉴 노출 테스트: OWNER만 노출되도록 기대값 변경
  * `수정 클릭 라우팅` 테스트: OWNER 케이스로 변경

---

## 🧪 테스트 시나리오

* [x] 마운트 시 `fetchGroups({ requesterId })` 호출 확인
* [x] OWNER 그룹: 액션 메뉴에 `수정` 노출
* [x] MANAGER/MEMBER 그룹: 액션 메뉴에 `수정` 미노출
* [x] OWNER가 `수정` 클릭 시 `GroupEdit`로 이동
* [x] 기존 탈퇴 관련 시나리오 영향 없음 (OWNER 탈퇴 불가 / MEMBER 탈퇴 가능)

> (라우터 가드 테스트가 별도 spec에 없다면) 로컬에서 `/groups/:groupId/edit` 직접 접근 시 owner 아닌 계정은 차단되는지 수동 확인 완료.

---

## 💡 기타 / 리뷰 포인트

* 서버에서 OWNER-only 권한 강제가 이미 적용되어 있어, 프론트는 “정책 일관성 + 우회 진입 방지 + UX 개선” 목적입니다.
* 이후 “BoardCreate/Edit는 manager 허용” 같은 권한 정책은 기존 로직 그대로 유지됩니다(변경 범위 최소화).

---

## 체크리스트

* [x] 정책 변경이 UI/라우트/테스트 전반에 일관되게 반영됨
* [x] 기존 기능 영향 최소화
* [x] 로컬 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 그룹 편집 권한이 소유자(OWNER)로 제한되었습니다. 관리자(MANAGER)는 편집 메뉴가 보이지 않으며, 편집 페이지 접근 시 차단되어 알림 후 목록으로 리다이렉트됩니다.

* **Tests**
  * 권한 변경에 맞춰 시나리오를 업데이트하고, 관리자가 편집 메뉴 및 편집 페이지에 접근할 수 없음을 검증하는 테스트를 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->