### PR TITLE
[BSM-78] fix: exclude owner from member search results

### DIFF
--- a/src/components/group/GroupForm.vue
+++ b/src/components/group/GroupForm.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from "vue";
 import { searchMembers, members } from "../../data/memberStore";
+import { useAuthStore } from "../../data/authStore";
 
 const props = defineProps({
   // "create" | "edit"
@@ -53,6 +54,10 @@ const selectedMembers = ref([]);
 // 로컬 에러 (유효성)
 const formError = ref("");
 
+// 그룹 생성자 정보
+const auth = useAuthStore();
+const ownerId = computed(() => Number(auth.user.value?.id));
+
 // ----- 초기값 세팅 (수정 모드일 때) -----
 function syncFromInitialGroup() {
   title.value = props.initialGroup.title || "";
@@ -94,7 +99,10 @@ async function handleSearchMembers() {
 
   try {
     const results = await searchMembers(memberSearch.value);
-    searchResults.value = results;
+    const oid = ownerId.value;
+    searchResults.value = Number.isFinite(oid)
+      ? results.filter((u) => Number(u.id) !== oid)
+      : results;
   } catch (e) {
     console.error(e);
     formError.value = "멤버 검색 중 오류가 발생했습니다.";

--- a/tests/GroupForm.spec.js
+++ b/tests/GroupForm.spec.js
@@ -12,6 +12,24 @@ function findButtonByText(wrapper, text) {
 }
 
 /**
+ * authStore 모킹
+ * - GroupForm은 "../../data/authStore" 를 import하지만,
+ *   테스트 번들 경로 기준 "../src/data/authStore" 로 매핑됨
+ * - ownerId 필터링을 위해 user.id를 테스트에서 바꿀 수 있게 export
+ */
+vi.mock("../src/data/authStore", () => {
+  const user = { value: { id: 1, name: "현재소유자", nickname: "owner" } };
+
+  return {
+    __esModule: true,
+    useAuthStore: () => ({
+      user,
+    }),
+    user,
+  };
+});
+
+/**
  * memberStore 모킹
  * - GroupForm은 "../../data/memberStore" 를 import하지만,
  *   번들링 경로 기준으로 "../src/data/memberStore" 가 동일 모듈로 매핑됨
@@ -29,6 +47,7 @@ vi.mock("../src/data/memberStore", () => {
 
 // 모킹된 함수/변수 import
 import { members, searchMembers } from "../src/data/memberStore";
+import { user as authUser } from "../src/data/authStore";
 
 const BASE_MEMBERS = [
   { id: 1, name: "김청강", nickname: "cheonggang" },
@@ -41,6 +60,8 @@ describe("GroupForm.vue", () => {
     // 각 테스트마다 초기화
     members.value = [...BASE_MEMBERS];
     searchMembers.mockReset();
+
+    authUser.value = { id: 1, name: "현재소유자", nickname: "owner" };
   });
 
   it("그룹 이름 / 설명 / 공개 범위를 입력 및 선택할 수 있다", async () => {
@@ -114,6 +135,38 @@ describe("GroupForm.vue", () => {
     // 오른쪽 상태 뱃지: 기본은 "추가"
     const statusBadge = first.find("span");
     expect(statusBadge.text()).toContain("추가");
+  });
+
+  it("멤버 검색 결과에서 owner(현재 로그인 사용자)는 노출되지 않는다", async () => {
+    // 현재 로그인 유저를 id=2로 설정
+    authUser.value = { id: 2, name: "이알고", nickname: "algoLee" };
+
+    // 검색 결과에 owner(id=2)를 포함시켜도 UI에는 보이면 안 됨
+    searchMembers.mockResolvedValue([
+      { id: 2, name: "이알고", nickname: "algoLee" }, // owner
+      { id: 3, name: "달피곰", nickname: "baekjoonPark" },
+    ]);
+
+    const wrapper = mount(GroupForm, { props: { mode: "create" } });
+
+    await wrapper
+      .find('input[placeholder="이름 또는 닉네임으로 검색"]')
+      .setValue("알고");
+    const searchButton = findButtonByText(wrapper, "검색");
+    await searchButton.trigger("click");
+    await flushPromises();
+
+    const searchBox = wrapper.findAll("div.border.rounded-xl")[0];
+    const resultItems = searchBox.findAll("li");
+
+    // owner가 빠져서 1개만 남아야 함
+    expect(resultItems.length).toBe(1);
+    expect(searchBox.text()).toContain("달피곰");
+    expect(searchBox.text()).toContain("@baekjoonPark");
+
+    // owner는 검색 결과에 없어야 함
+    expect(searchBox.text()).not.toContain("이알고");
+    expect(searchBox.text()).not.toContain("@algoLee");
   });
 
   it("멤버 검색 결과에서 클릭 시 선택됨/추가 상태와 오른쪽 선택된 멤버 영역이 동기화된다", async () => {


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/78
---
## ✅ **구현 내용**

* GroupForm 멤버 검색 결과에서 **현재 로그인 유저(owner)** 가 노출되지 않도록 필터링 추가
* `searchMembers()` 결과를 세팅하기 전에 `ownerId`와 일치하는 유저를 제외 처리
* `ownerId`가 아직 준비되지 않은 경우(로그인 정보 미로딩 등)에는 필터링 없이 기존 동작 유지

## 📂 **변경 모듈**

* `src/components/group/GroupForm.vue`

  * `useAuthStore()` 기반 `ownerId` 계산 추가
  * `handleSearchMembers()`에서 검색 결과 owner 제외 필터 적용
* `tests/GroupForm.spec.js` (또는 해당 테스트 파일 경로)

  * `authStore` mock 추가
  * “검색 결과에 owner가 포함되어도 UI에는 노출되지 않음” 테스트 케이스 추가/보강

## 🧪 **시나리오**

* [x] 멤버 검색 시 검색 결과에 owner(현재 로그인 유저)가 포함되어 반환되더라도 **리스트에 표시되지 않음**
* [x] owner가 아닌 멤버는 정상적으로 검색 결과에 표시됨
* [x] 검색 결과 클릭 → 선택됨/추가 뱃지 토글 및 오른쪽 “선택된 멤버” 동기화 정상
* [x] 선택된 멤버 X 제거 시 오른쪽 목록에서 제거되고 왼쪽 뱃지는 “추가”로 복귀
* [x] 검색 중 로딩(“검색 중…”) 표시 및 실패 시 에러 메시지 표시 정상

## 💡 **기타**

* 그룹 생성자는 자동으로 owner로 포함되는 정책이므로, 검색 결과에서 제외해 **중복 선택 시도/혼란을 방지**하고 UX를 일관되게 유지했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 그룹 멤버 검색 결과에서 현재 로그인한 사용자가 제외되도록 개선되었습니다.

* **테스트**
  * 멤버 검색 필터링 동작을 검증하는 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->