### PR TITLE
[BSM-81] refactor: replace alert/confirm with global toast & confirm dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,13 @@
 <script setup>
 import AppHeader from "./components/AppHeader.vue";
+import AppToastHost from "./components/ui/AppToastHost.vue";
+import ConfirmDialog from "./components/ui/ConfirmDialog.vue";
 </script>
 
 <template>
   <AppHeader />
   <router-view />
+
+  <AppToastHost />
+  <ConfirmDialog />
 </template>

--- a/src/components/BoardList.vue
+++ b/src/components/BoardList.vue
@@ -4,6 +4,8 @@ import { useRouter, useRoute } from "vue-router";
 import { boards, deleteBoard, fetchBoards } from "../data/boardStore";
 import { useAuthStore } from "../data/authStore";
 import { fetchGroupById } from "../data/groupStore";
+import { toast } from "@/lib/feedback/toast";
+import { confirm } from "@/lib/feedback/confirm";
 
 const router = useRouter();
 const route = useRoute();
@@ -105,23 +107,33 @@ function goGroupList() {
 
 async function handleDelete(id) {
   if (!currentUserId.value) {
-    alert("로그인이 필요합니다.");
+    toast.warning("로그인이 필요합니다.");
     return;
   }
 
-  if (confirm("정말 이 보드를 삭제하시겠습니까?")) {
-    try {
-      await deleteBoard({
-        groupId: Number(route.params.groupId),
-        boardId: id,
-        requesterId: currentUserId.value,
-      });
+  const ok = await confirm({
+    title: "보드 삭제",
+    description: "정말 이 보드를 삭제하시겠습니까?",
+    confirmText: "삭제",
+    cancelText: "취소",
+    variant: "danger",
+  });
+  if (!ok) return;
 
-      await fetchBoards(Number(route.params.groupId));
-    } catch (e) {
-      console.error(e);
-      alert("보드 삭제 중 오류가 발생했습니다: " + e.message);
-    }
+  try {
+    await deleteBoard({
+      groupId: Number(route.params.groupId),
+      boardId: id,
+      requesterId: currentUserId.value,
+    });
+
+    await fetchBoards(Number(route.params.groupId));
+    toast.success("보드를 삭제했습니다.");
+  } catch (e) {
+    console.error(e);
+    toast.error(
+      `보드 삭제 중 오류가 발생했습니다${e?.message ? `: ${e.message}` : "."}`,
+    );
   }
 }
 </script>

--- a/src/components/board/SelectedProblemsPanel.vue
+++ b/src/components/board/SelectedProblemsPanel.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed } from "vue";
 import { difficultyOptions } from "@/data/difficultyOptions";
+import { confirm } from "@/lib/feedback/confirm";
 
 const props = defineProps({
   problems: {
@@ -28,9 +29,15 @@ function handleDrop(index) {
   draggingIndex.value = null;
 }
 
-function handleClearAll() {
+async function handleClearAll() {
   if (!props.problems.length) return;
-  const ok = window.confirm("선택된 문제를 모두 삭제할까요?");
+  const ok = await confirm({
+    title: "전체 삭제",
+    description: "선택된 문제를 모두 삭제할까요?",
+    confirmText: "삭제",
+    cancelText: "취소",
+    variant: "danger",
+  });
   if (!ok) return;
   emit("clear-all");
 }

--- a/src/components/group/GroupList.vue
+++ b/src/components/group/GroupList.vue
@@ -3,6 +3,8 @@ import { ref, onMounted, onUnmounted, computed, nextTick } from "vue";
 import { useRouter } from "vue-router";
 import { groups, fetchGroups, leaveGroup } from "../../data/groupStore";
 import { useAuthStore } from "../../data/authStore";
+import { toast } from "@/lib/feedback/toast";
+import { confirm } from "@/lib/feedback/confirm";
 
 const router = useRouter();
 const authStore = useAuthStore();
@@ -77,7 +79,8 @@ onMounted(async () => {
     console.warn(
       "[GroupList] currentUserId가 없어 그룹 목록을 불러오지 않습니다.",
     );
-    window.alert("로그인이 필요합니다.");
+    toast.warning("로그인이 필요합니다.");
+    router.replace({ name: "Login", query: { redirect: "/groups" } });
     return;
   }
   await fetchGroups({ requesterId: uid });
@@ -146,30 +149,36 @@ async function handleLeaveGroup(groupId) {
   const uid = currentUserId.value;
 
   if (!uid) {
-    window.alert("로그인 정보가 없어 그룹을 탈퇴할 수 없습니다.");
+    toast.error("로그인 정보가 없어 그룹을 탈퇴할 수 없습니다.");
     return;
   }
 
   if (isOwner(target)) {
-    window.alert(
+    toast.info(
       "이 그룹의 소유자는 바로 탈퇴할 수 없습니다.\n" +
         "그룹 수정 > 소유자 변경에서 소유권을 다른 멤버에게 넘긴 뒤 탈퇴해 주세요.",
     );
     return;
   }
 
-  const ok = window.confirm(
-    `정말 '${name}' 그룹에서 탈퇴하시겠습니까?\n` +
+  const ok = await confirm({
+    title: "그룹 탈퇴",
+    description:
+      `정말 '${name}' 그룹에서 탈퇴하시겠습니까?\n` +
       "탈퇴해도 기존에 풀었던 문제 기록은 유지되지만, 이 그룹의 보드에는 더 이상 접근할 수 없습니다.",
-  );
+    confirmText: "탈퇴",
+    cancelText: "취소",
+    variant: "danger",
+  });
   if (!ok) return;
 
   try {
     leavingGroupId.value = groupId;
     await leaveGroup(groupId, { requesterId: uid });
+    toast.success("그룹에서 탈퇴했습니다.");
   } catch (e) {
     console.error(e);
-    alert("그룹 탈퇴 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    toast.error("그룹 탈퇴 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
   } finally {
     leavingGroupId.value = null;
   }

--- a/src/components/ui/AppToastHost.vue
+++ b/src/components/ui/AppToastHost.vue
@@ -1,0 +1,69 @@
+<script setup>
+import { computed } from "vue";
+import { toasts, toast as toastApi } from "@/lib/feedback/toast";
+
+const items = computed(() => toasts.value);
+
+const styleFor = (type) => {
+  switch (type) {
+    case "success":
+      return "border-green-200 bg-green-50 text-green-800";
+    case "info":
+      return "border-blue-200 bg-blue-50 text-blue-800";
+    case "warning":
+      return "border-yellow-200 bg-yellow-50 text-yellow-900";
+    case "error":
+      return "border-red-200 bg-red-50 text-red-800";
+    default:
+      return "border-gray-200 bg-white text-gray-800";
+  }
+};
+</script>
+
+<template>
+  <div
+    class="fixed top-3 right-3 z-[9999] flex flex-col gap-2"
+    role="region"
+    aria-live="polite"
+    aria-relevant="additions"
+  >
+    <transition-group
+      name="toast"
+      tag="div"
+      class="flex flex-col gap-2"
+    >
+      <div
+        v-for="t in items"
+        :key="t.id"
+        class="min-w-[260px] max-w-[360px] rounded-xl border px-3 py-2 shadow-sm"
+        :class="styleFor(t.type)"
+      >
+        <div class="flex items-start gap-2">
+          <div class="flex-1 text-sm leading-snug break-words">
+            {{ t.message }}
+          </div>
+          <button
+            type="button"
+            class="shrink-0 rounded-md px-2 py-1 text-xs font-semibold hover:bg-black/5"
+            aria-label="알림 닫기"
+            @click="toastApi.remove(t.id)"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+    </transition-group>
+  </div>
+</template>
+
+<style scoped>
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.18s ease;
+}
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+</style>

--- a/src/components/ui/ConfirmDialog.vue
+++ b/src/components/ui/ConfirmDialog.vue
@@ -1,10 +1,74 @@
 <script setup>
-import { computed, onMounted, onUnmounted } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import { confirmState, resolveConfirm } from "@/lib/feedback/confirm";
 
 const state = confirmState;
+
 const isOpen = computed(() => state.isOpen);
 const isDanger = computed(() => state.variant === "danger");
+const role = computed(() => (isDanger.value ? "alertdialog" : "dialog"));
+
+const overlayRef = ref(null);
+const dialogRef = ref(null);
+const cancelBtnRef = ref(null);
+const confirmBtnRef = ref(null);
+
+const uid = Math.random().toString(36).slice(2, 9);
+const titleId = `confirm-title-${uid}`;
+const descId = `confirm-desc-${uid}`;
+
+let prevActiveEl = null;
+let prevBodyOverflow = "";
+
+function getFocusable(container) {
+  if (!container) return [];
+  const selectors = [
+    "a[href]",
+    "area[href]",
+    'input:not([disabled]):not([type="hidden"])',
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    "button:not([disabled])",
+    "iframe",
+    "object",
+    "embed",
+    '[contenteditable="true"]',
+    '[tabindex]:not([tabindex="-1"])',
+  ];
+  return Array.from(container.querySelectorAll(selectors.join(","))).filter(
+    (el) => el.offsetParent !== null,
+  );
+}
+
+function lockScroll() {
+  prevBodyOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+}
+
+function unlockScroll() {
+  document.body.style.overflow = prevBodyOverflow || "";
+}
+
+function hideAppFromSR(hide) {
+  const app = document.getElementById("app");
+  if (!app) return;
+  if (hide) app.setAttribute("aria-hidden", "true");
+  else app.removeAttribute("aria-hidden");
+}
+
+async function focusInitial() {
+  await nextTick();
+  const target =
+    state.initialFocus === "cancel" ? cancelBtnRef.value : confirmBtnRef.value;
+
+  if (target?.focus) {
+    target.focus();
+    return;
+  }
+  // fallback
+  const list = getFocusable(dialogRef.value);
+  list[0]?.focus?.();
+}
 
 function onCancel() {
   resolveConfirm(false);
@@ -15,46 +79,112 @@ function onConfirm() {
 }
 
 function onBackdropClick(e) {
+  if (!state.closeOnBackdrop) return;
   if (e.target === e.currentTarget) onCancel();
+}
+
+function trapTab(e) {
+  if (e.key !== "Tab") return;
+
+  const focusables = getFocusable(dialogRef.value);
+  if (focusables.length === 0) {
+    e.preventDefault();
+    return;
+  }
+
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement;
+
+  if (e.shiftKey) {
+    if (active === first || !dialogRef.value?.contains(active)) {
+      e.preventDefault();
+      last.focus();
+    }
+  } else {
+    if (active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
 }
 
 function onKeydown(e) {
   if (!state.isOpen) return;
-  if (e.key === "Escape") onCancel();
+
+  if (e.key === "Escape") {
+    e.preventDefault();
+    onCancel();
+    return;
+  }
+
+  trapTab(e);
 }
 
-onMounted(() => window.addEventListener("keydown", onKeydown));
-onUnmounted(() => window.removeEventListener("keydown", onKeydown));
+watch(
+  () => state.isOpen,
+  async (open) => {
+    if (open) {
+      prevActiveEl = document.activeElement;
+      lockScroll();
+      hideAppFromSR(true);
+      window.addEventListener("keydown", onKeydown);
+      await focusInitial();
+    } else {
+      window.removeEventListener("keydown", onKeydown);
+      hideAppFromSR(false);
+      unlockScroll();
+      // restore focus
+      prevActiveEl?.focus?.();
+      prevActiveEl = null;
+    }
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKeydown);
+  hideAppFromSR(false);
+  unlockScroll();
+});
 </script>
 
 <template>
   <teleport to="body">
     <div
       v-if="isOpen"
+      ref="overlayRef"
       class="fixed inset-0 z-[9998] flex items-center justify-center"
       @click="onBackdropClick"
     >
       <div class="absolute inset-0 bg-black/30" />
 
       <div
+        ref="dialogRef"
         class="relative w-[92%] max-w-[420px] rounded-2xl bg-white shadow-xl border border-gray-200 p-5"
-        role="dialog"
+        :role="role"
         aria-modal="true"
-        :aria-label="state.title"
+        :aria-labelledby="titleId"
+        :aria-describedby="state.description ? descId : undefined"
       >
-        <div class="text-base font-bold text-gray-900">
+        <div
+          :id="titleId"
+          class="text-base font-bold text-gray-900"
+        >
           {{ state.title }}
         </div>
 
         <div
           v-if="state.description"
-          class="mt-2 text-sm text-gray-600"
+          :id="descId"
+          class="mt-2 text-sm text-gray-600 whitespace-pre-line"
         >
           {{ state.description }}
         </div>
 
         <div class="mt-5 flex items-center justify-end gap-2">
           <button
+            ref="cancelBtnRef"
             type="button"
             class="px-3 py-2 rounded-xl text-sm font-semibold border border-gray-300 text-gray-700 bg-white hover:bg-gray-50"
             @click="onCancel"
@@ -63,6 +193,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
           </button>
 
           <button
+            ref="confirmBtnRef"
             type="button"
             class="px-3 py-2 rounded-xl text-sm font-semibold text-white"
             :class="

--- a/src/components/ui/ConfirmDialog.vue
+++ b/src/components/ui/ConfirmDialog.vue
@@ -1,0 +1,81 @@
+<script setup>
+import { computed, onMounted, onUnmounted } from "vue";
+import { confirmState, resolveConfirm } from "@/lib/feedback/confirm";
+
+const state = confirmState;
+const isOpen = computed(() => state.isOpen);
+const isDanger = computed(() => state.variant === "danger");
+
+function onCancel() {
+  resolveConfirm(false);
+}
+
+function onConfirm() {
+  resolveConfirm(true);
+}
+
+function onBackdropClick(e) {
+  if (e.target === e.currentTarget) onCancel();
+}
+
+function onKeydown(e) {
+  if (!state.isOpen) return;
+  if (e.key === "Escape") onCancel();
+}
+
+onMounted(() => window.addEventListener("keydown", onKeydown));
+onUnmounted(() => window.removeEventListener("keydown", onKeydown));
+</script>
+
+<template>
+  <teleport to="body">
+    <div
+      v-if="isOpen"
+      class="fixed inset-0 z-[9998] flex items-center justify-center"
+      @click="onBackdropClick"
+    >
+      <div class="absolute inset-0 bg-black/30" />
+
+      <div
+        class="relative w-[92%] max-w-[420px] rounded-2xl bg-white shadow-xl border border-gray-200 p-5"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="state.title"
+      >
+        <div class="text-base font-bold text-gray-900">
+          {{ state.title }}
+        </div>
+
+        <div
+          v-if="state.description"
+          class="mt-2 text-sm text-gray-600"
+        >
+          {{ state.description }}
+        </div>
+
+        <div class="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            class="px-3 py-2 rounded-xl text-sm font-semibold border border-gray-300 text-gray-700 bg-white hover:bg-gray-50"
+            @click="onCancel"
+          >
+            {{ state.cancelText }}
+          </button>
+
+          <button
+            type="button"
+            class="px-3 py-2 rounded-xl text-sm font-semibold text-white"
+            :class="
+              isDanger
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-yellow-500 hover:bg-yellow-600'
+            "
+            @click="onConfirm"
+          >
+            {{ state.confirmText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </teleport>
+</template>

--- a/src/lib/feedback/confirm.js
+++ b/src/lib/feedback/confirm.js
@@ -1,0 +1,43 @@
+import { reactive, readonly } from "vue";
+
+/**
+ * Tiny global confirm dialog state.
+ * Use from anywhere:
+ *   const ok = await confirm({ title, description })
+ */
+
+const _state = reactive({
+  isOpen: false,
+  title: "확인",
+  description: "",
+  confirmText: "확인",
+  cancelText: "취소",
+  variant: "default", // default | danger
+  _resolver: null,
+});
+
+export const confirmState = readonly(_state);
+
+export function confirm(options = {}) {
+  return new Promise((resolve) => {
+    _state.title = options.title ?? "확인";
+    _state.description = options.description ?? "";
+    _state.confirmText = options.confirmText ?? "확인";
+    _state.cancelText = options.cancelText ?? "취소";
+    _state.variant = options.variant ?? "default";
+
+    _state._resolver = resolve;
+    _state.isOpen = true;
+  });
+}
+
+export function resolveConfirm(result) {
+  try {
+    if (typeof _state._resolver === "function") {
+      _state._resolver(Boolean(result));
+    }
+  } finally {
+    _state.isOpen = false;
+    _state._resolver = null;
+  }
+}

--- a/src/lib/feedback/confirm.js
+++ b/src/lib/feedback/confirm.js
@@ -3,7 +3,7 @@ import { reactive, readonly } from "vue";
 /**
  * Tiny global confirm dialog state.
  * Use from anywhere:
- *   const ok = await confirm({ title, description })
+ *   const ok = await confirm({ title, description, variant: "danger" })
  */
 
 const _state = reactive({
@@ -13,12 +13,23 @@ const _state = reactive({
   confirmText: "확인",
   cancelText: "취소",
   variant: "default", // default | danger
+
+  // options
+  closeOnBackdrop: true,
+  initialFocus: "confirm", // confirm | cancel
+
   _resolver: null,
 });
 
 export const confirmState = readonly(_state);
 
 export function confirm(options = {}) {
+  if (_state.isOpen && typeof _state._resolver === "function") {
+    _state._resolver(false);
+    _state._resolver = null;
+    _state.isOpen = false;
+  }
+
   return new Promise((resolve) => {
     _state.title = options.title ?? "확인";
     _state.description = options.description ?? "";

--- a/src/lib/feedback/toast.js
+++ b/src/lib/feedback/toast.js
@@ -45,13 +45,12 @@ function push(type, message, options = {}) {
   if (_toasts.value.length > MAX_TOASTS) {
     const overflow = _toasts.value.length - MAX_TOASTS;
     const dropIds = _toasts.value.slice(0, overflow).map((t) => t.id);
-    dropIds.forEach((dropId) => remove(dropId));
+    dropIds.forEach(clearTimer);
     _toasts.value = _toasts.value.slice(-MAX_TOASTS);
   }
 
   if (duration > 0) {
     const timeoutId = window.setTimeout(() => {
-      _timeouts.delete(id);
       remove(id);
     }, duration);
     _timeouts.set(id, timeoutId);

--- a/src/lib/feedback/toast.js
+++ b/src/lib/feedback/toast.js
@@ -1,7 +1,7 @@
 import { ref, readonly } from "vue";
 
 /**
- * Tiny global toast store (framework-agnostic).
+ * Tiny global toast store (Vue-based).
  * - Works from anywhere (router, services, components)
  * - Keeps UI in <AppToastHost />
  */

--- a/src/lib/feedback/toast.js
+++ b/src/lib/feedback/toast.js
@@ -7,9 +7,20 @@ import { ref, readonly } from "vue";
  */
 
 const _toasts = ref([]);
+const _timeouts = new Map();
+const MAX_TOASTS = 5;
 let _seq = 1;
 
+function clearTimer(id) {
+  const tid = _timeouts.get(id);
+  if (tid) {
+    clearTimeout(tid);
+    _timeouts.delete(id);
+  }
+}
+
 function remove(id) {
+  clearTimer(id);
   _toasts.value = _toasts.value.filter((t) => t.id !== id);
 }
 
@@ -31,8 +42,19 @@ function push(type, message, options = {}) {
 
   _toasts.value = [..._toasts.value, toast];
 
+  if (_toasts.value.length > MAX_TOASTS) {
+    const overflow = _toasts.value.length - MAX_TOASTS;
+    const dropIds = _toasts.value.slice(0, overflow).map((t) => t.id);
+    dropIds.forEach((dropId) => remove(dropId));
+    _toasts.value = _toasts.value.slice(-MAX_TOASTS);
+  }
+
   if (duration > 0) {
-    window.setTimeout(() => remove(id), duration);
+    const timeoutId = window.setTimeout(() => {
+      _timeouts.delete(id);
+      remove(id);
+    }, duration);
+    _timeouts.set(id, timeoutId);
   }
 
   return id;
@@ -45,6 +67,7 @@ export const toast = {
   error: (message, options) => push("error", message, options),
   remove,
   clear: () => {
+    Array.from(_timeouts.keys()).forEach((id) => clearTimer(id));
     _toasts.value = [];
   },
 };

--- a/src/lib/feedback/toast.js
+++ b/src/lib/feedback/toast.js
@@ -1,0 +1,52 @@
+import { ref, readonly } from "vue";
+
+/**
+ * Tiny global toast store (framework-agnostic).
+ * - Works from anywhere (router, services, components)
+ * - Keeps UI in <AppToastHost />
+ */
+
+const _toasts = ref([]);
+let _seq = 1;
+
+function remove(id) {
+  _toasts.value = _toasts.value.filter((t) => t.id !== id);
+}
+
+function push(type, message, options = {}) {
+  const id = _seq++;
+  const duration = Number.isFinite(options.duration)
+    ? options.duration
+    : type === "error"
+      ? 5000
+      : 3000;
+
+  const toast = {
+    id,
+    type,
+    message,
+    duration,
+    createdAt: Date.now(),
+  };
+
+  _toasts.value = [..._toasts.value, toast];
+
+  if (duration > 0) {
+    window.setTimeout(() => remove(id), duration);
+  }
+
+  return id;
+}
+
+export const toast = {
+  success: (message, options) => push("success", message, options),
+  info: (message, options) => push("info", message, options),
+  warning: (message, options) => push("warning", message, options),
+  error: (message, options) => push("error", message, options),
+  remove,
+  clear: () => {
+    _toasts.value = [];
+  },
+};
+
+export const toasts = readonly(_toasts);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,8 @@ import BoardDetailView from "../views/BoardDetailView.vue";
 import { fetchGroupById } from "@/data/groupStore";
 import { useAuthStore } from "@/data/authStore";
 
+import { toast } from "@/lib/feedback/toast";
+
 const routes = [
   {
     path: "/",
@@ -166,7 +168,7 @@ router.beforeEach(async (to, from, next) => {
       group = await fetchGroupById(groupId, { requesterId: uid });
     } catch (e) {
       if (e?.response?.status === 401) {
-        window.alert("로그인이 필요합니다.");
+        toast.warning("로그인이 필요합니다.");
 
         return next({
           name: "Login",
@@ -176,12 +178,12 @@ router.beforeEach(async (to, from, next) => {
       }
 
       console.error("[router] fetchGroupById error:", e);
-      window.alert("그룹 정보를 불러올 수 없습니다.");
+      toast.error("그룹 정보를 불러올 수 없습니다.");
       return next({ name: "GroupList" });
     }
 
     if (!group) {
-      window.alert("해당 그룹을 찾을 수 없습니다.");
+      toast.error("해당 그룹을 찾을 수 없습니다.");
       return next({ name: "GroupList" });
     }
 
@@ -199,19 +201,19 @@ router.beforeEach(async (to, from, next) => {
 
     // 4-1) 그룹 멤버만 접근 가능한 페이지 (BoardList, BoardDetail 등)
     if (needGroupMember && !isMember) {
-      window.alert("이 그룹 멤버만 접근할 수 있는 페이지입니다.");
+      toast.warning("이 그룹 멤버만 접근할 수 있는 페이지입니다.");
       return next({ name: "GroupList" });
     }
 
     // 4-1.5) owner만 접근 가능한 페이지 (GroupEdit 등)
     if (needGroupOwner && !isOwner) {
-      window.alert("이 그룹의 소유자만 접근할 수 있습니다.");
+      toast.warning("이 그룹의 소유자만 접근할 수 있습니다.");
       return next({ name: "GroupList" });
     }
 
     // 4-2) owner/manager만 접근 가능한 페이지 (BoardCreate/Edit)
     if (needGroupManager && !(isOwner || isManager)) {
-      window.alert("이 그룹의 관리자 또는 소유자만 접근할 수 있습니다.");
+      toast.warning("이 그룹의 관리자 또는 소유자만 접근할 수 있습니다.");
 
       const isBoardRoute = [
         "BoardList",

--- a/tests/BoardList.spec.js
+++ b/tests/BoardList.spec.js
@@ -3,6 +3,27 @@ import { ref, nextTick } from "vue";
 import { mount, flushPromises } from "@vue/test-utils";
 
 // =======================
+// 0) feedback mocks
+// =======================
+vi.mock("@/lib/feedback/confirm", () => ({
+  __esModule: true,
+  confirm: vi.fn(),
+}));
+
+vi.mock("@/lib/feedback/toast", () => ({
+  __esModule: true,
+  toast: {
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  },
+  toasts: { value: [] },
+}));
+
+// =======================
 // 1) vue-router mock
 // =======================
 const pushMock = vi.fn();

--- a/tests/BoardList.spec.js
+++ b/tests/BoardList.spec.js
@@ -104,6 +104,7 @@ import {
 } from "@/data/boardStore";
 import { fetchGroupById as fetchGroupByIdMock } from "@/data/groupStore";
 import { useAuthStore } from "@/data/authStore";
+import { confirm as confirmMock } from "@/lib/feedback/confirm";
 
 describe("BoardList.vue", () => {
   beforeEach(() => {
@@ -230,7 +231,7 @@ describe("BoardList.vue", () => {
   });
 
   it("삭제 버튼 클릭 시 confirm 통과하면 deleteBoard와 fetchBoards가 호출된다", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    confirmMock.mockResolvedValue(true);
 
     const wrapper = mount(BoardList);
     await flushPromises();
@@ -248,7 +249,7 @@ describe("BoardList.vue", () => {
     await nextTick();
 
     // 1) 동작 검증
-    expect(confirmSpy).toHaveBeenCalled();
+    expect(confirmMock).toHaveBeenCalled();
     expect(deleteBoardMock).toHaveBeenCalledWith({
       groupId: 1,
       boardId: 1,
@@ -261,8 +262,6 @@ describe("BoardList.vue", () => {
 
     // 3) DOM에서도 사라졌는지
     expect(wrapper.text()).not.toContain("알고리즘 스터디 1차");
-
-    confirmSpy.mockRestore();
   });
 
   it("권한이 없는 사용자는 보드 만들기/수정/삭제 버튼을 볼 수 없다", async () => {

--- a/tests/BoardList.spec.js
+++ b/tests/BoardList.spec.js
@@ -135,6 +135,7 @@ describe("BoardList.vue", () => {
     fetchBoardsMock.mockClear();
     pushMock.mockClear();
     fetchGroupByIdMock.mockClear();
+    confirmMock.mockReset();
   });
 
   it("마운트 시 fetchBoards가 groupId와 함께 호출된다", async () => {

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -2,6 +2,25 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref, nextTick } from "vue";
 import { mount, flushPromises } from "@vue/test-utils";
 
+// --- feedback mocks -------------------------------------------------
+vi.mock("@/lib/feedback/confirm", () => ({
+  __esModule: true,
+  confirm: vi.fn(),
+}));
+
+vi.mock("@/lib/feedback/toast", () => ({
+  __esModule: true,
+  toast: {
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  },
+  toasts: { value: [] },
+}));
+
 // --- vue-router mock -------------------------------------------------
 const pushMock = vi.fn();
 

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -63,6 +63,7 @@ import {
   fetchGroups as fetchGroupsMock,
   leaveGroup as leaveGroupMock,
 } from "../src/data/groupStore";
+import { confirm as confirmMock } from "@/lib/feedback/confirm";
 
 // 🔹 그룹 li를 이름으로 찾아주는 헬퍼 (정렬/필터에 의존 X)
 function findGroupItemByName(wrapper, groupName) {
@@ -238,8 +239,7 @@ describe("GroupList.vue", () => {
   });
 
   it("MEMBER 그룹에서 '그룹 탈퇴' 클릭 시 leaveGroup이 호출된다", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    confirmMock.mockResolvedValue(true);
 
     const wrapper = mount(GroupList);
     await flushPromises();
@@ -257,11 +257,8 @@ describe("GroupList.vue", () => {
     await flushPromises();
     await nextTick();
 
-    expect(confirmSpy).toHaveBeenCalled();
+    expect(confirmMock).toHaveBeenCalled();
     expect(leaveGroupMock).toHaveBeenCalledWith(3, { requesterId: 1 });
-
-    confirmSpy.mockRestore();
-    alertSpy.mockRestore();
   });
 
   it("그룹 카드를 클릭하면 BoardList로 이동한다", async () => {

--- a/tests/GroupList.spec.js
+++ b/tests/GroupList.spec.js
@@ -125,6 +125,7 @@ describe("GroupList.vue", () => {
     fetchGroupsMock.mockImplementation(async () => {});
     leaveGroupMock.mockReset();
     pushMock.mockReset();
+    confirmMock.mockReset();
   });
 
   it("마운트 시 fetchGroups가 호출된다", async () => {
@@ -212,9 +213,6 @@ describe("GroupList.vue", () => {
   });
 
   it("OWNER는 '탈퇴 불가'로 표시되고 leaveGroup이 호출되지 않는다", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm");
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
-
     const wrapper = mount(GroupList);
     await flushPromises();
     await nextTick();
@@ -230,12 +228,8 @@ describe("GroupList.vue", () => {
     // disabled라서 클릭 자체가 안 되는 게 정상
     expect(leaveBtn.element.disabled).toBe(true);
 
-    expect(confirmSpy).not.toHaveBeenCalled();
-    expect(alertSpy).not.toHaveBeenCalled();
+    expect(confirmMock).not.toHaveBeenCalled();
     expect(leaveGroupMock).not.toHaveBeenCalled();
-
-    confirmSpy.mockRestore();
-    alertSpy.mockRestore();
   });
 
   it("MEMBER 그룹에서 '그룹 탈퇴' 클릭 시 leaveGroup이 호출된다", async () => {


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/81
---
## ✅ 구현 내용

Global Toast + Confirm Dialog 도입

기존 alert/confirm 제거 및 UX 표준화(라우터 포함)

## 📂 변경 모듈

`src/lib/feedback/*`

`src/components/ui/*`

`src/App.vue`

`src/router/index.js`

`BoardList.vue`, `GroupList.vue`, `SelectedProblemsPanel.vue`

`tests/BoardList.spec.js`

`tests/GroupList.spec.js`

## 🧪 테스트 시나리오

보드 삭제 버튼 → confirm 노출 → 삭제 시 toast 성공/실패 표시

그룹 탈퇴 버튼 → confirm 노출 → 탈퇴 성공/실패 toast 표시

권한 없는 그룹 접근 → toast로 안내 후 적절히 리다이렉트

## 💡 기타

- 라우터/서비스 등 “컴포넌트 외부”에서도 사용 가능한 전역 피드백 레이어 기반 마련
- 브라우저가 가지고 있던 통제를 컴포넌트로 옮김

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 전역 토스트 호스트 및 토스트 API 추가로 화면 상단 플로팅 알림 제공
  * 재사용 가능한 확인(Confirm) 모달 컴포넌트 및 API 추가

* **개선 사항**
  * 기존 브라우저 alert/confirm을 토스트와 확인 모달로 대체해 일관된 피드백 및 확인 흐름 제공
  * 삭제, 전체 삭제, 그룹 탈퇴 등 주요 사용자 액션에 확인 모달과 성공/오류 토스트 적용

* **테스트**
  * 피드백 모듈을 모킹하도록 테스트 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->