### PR TITLE
[BSM-83] feat: Introduce a Zod-based API contract validation layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "flowbite-vue": "^0.2.2",
         "vue": "^3.5.0",
         "vue-router": "^4.6.3",
-        "vue-virtual-scroller": "^2.0.0-beta.8"
+        "vue-virtual-scroller": "^2.0.0-beta.8",
+        "zod": "^3.25.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -7498,6 +7499,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "flowbite-vue": "^0.2.2",
     "vue": "^3.5.0",
     "vue-router": "^4.6.3",
-    "vue-virtual-scroller": "^2.0.0-beta.8"
+    "vue-virtual-scroller": "^2.0.0-beta.8",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/lib/schema/assertSchema.js
+++ b/src/lib/schema/assertSchema.js
@@ -1,6 +1,19 @@
 import { ApiSchemaError } from "./errors";
 
 /**
+ * DEV/TEST 환경 판별 (Vite/Vitest 기준)
+ */
+export function isDevEnv() {
+  return (
+    typeof import.meta !== "undefined" &&
+    import.meta.env &&
+    (import.meta.env.DEV ||
+      import.meta.env.MODE === "test" ||
+      import.meta.env.MODE === "development")
+  );
+}
+
+/**
  * Validate an API response at the service boundary.
  * - Throws ApiSchemaError on mismatch (fast-fail).
  * - Logs details in DEV for debugging.
@@ -22,12 +35,7 @@ export function assertSchema(schema, data, context) {
   }));
 
   // Avoid crashing if import.meta is not available (unit tests / non-vite env)
-  const isDev =
-    typeof import.meta !== "undefined" &&
-    import.meta.env &&
-    (import.meta.env.DEV || import.meta.env.MODE === "development");
-
-  if (isDev) {
+  if (isDevEnv()) {
     // eslint-disable-next-line no-console
     console.error("[API_SCHEMA_INVALID]", { context, issues, data });
   }

--- a/src/lib/schema/assertSchema.js
+++ b/src/lib/schema/assertSchema.js
@@ -1,0 +1,36 @@
+import { ApiSchemaError } from "./errors";
+
+/**
+ * Validate an API response at the service boundary.
+ * - Throws ApiSchemaError on mismatch (fast-fail).
+ * - Logs details in DEV for debugging.
+ *
+ * @template T
+ * @param {import("zod").ZodType<T>} schema
+ * @param {unknown} data
+ * @param {string} context
+ * @returns {T}
+ */
+export function assertSchema(schema, data, context) {
+  const result = schema.safeParse(data);
+  if (result.success) return result.data;
+
+  const issues = result.error.issues?.map((i) => ({
+    path: i.path?.join("."),
+    code: i.code,
+    message: i.message,
+  }));
+
+  // Avoid crashing if import.meta is not available (unit tests / non-vite env)
+  const isDev =
+    typeof import.meta !== "undefined" &&
+    import.meta.env &&
+    (import.meta.env.DEV || import.meta.env.MODE === "development");
+
+  if (isDev) {
+    // eslint-disable-next-line no-console
+    console.error("[API_SCHEMA_INVALID]", { context, issues, data });
+  }
+
+  throw new ApiSchemaError({ context, issues });
+}

--- a/src/lib/schema/board.schema.js
+++ b/src/lib/schema/board.schema.js
@@ -1,0 +1,61 @@
+import { z, Id, Int, NullableDateTimeString } from "./primitives";
+import { ApiProblemSchema } from "./problem.schema";
+
+/**
+ * Board summary returned from GET /groups/{groupId}/boards
+ * (fields based on src/services/boardService.js mapBoardSummaryFromApi)
+ */
+export const ApiBoardSummarySchema = z
+  .object({
+    boardId: Id,
+    title: z.string().min(1),
+    endTime: NullableDateTimeString.optional(),
+    problemsCount: Int.optional(),
+  })
+  .passthrough();
+
+export const ApiBoardSummaryListSchema = z.array(ApiBoardSummarySchema);
+
+/**
+ * Board detail returned from GET /groups/{groupId}/boards/{boardId}
+ * (fields based on src/services/boardService.js mapBoardDetailFromApi)
+ */
+export const ApiBoardDetailSchema = z
+  .object({
+    boardId: Id,
+    groupId: Id.optional(),
+    title: z.string().min(1),
+    content: z.string().optional(),
+    startTime: NullableDateTimeString.optional(),
+    endTime: NullableDateTimeString.optional(),
+    problems: z.array(z.union([ApiProblemSchema, Id])).optional(),
+  })
+  .passthrough();
+
+/**
+ * Board progress returned from GET /groups/{groupId}/boards/{boardId}/userStatus
+ */
+export const ApiBoardProgressSchema = z
+  .object({
+    boardId: Id.optional(),
+    problemStatus: z
+      .array(
+        z.object({
+          problemId: Id,
+          solvedUserIds: z.array(Id).optional(),
+        }).passthrough(),
+      )
+      .optional(),
+    userStatus: z
+      .array(
+        z.object({
+          userId: Id,
+          username: z.string().optional(),
+          solvedProblemIds: z.array(Id).optional(),
+          solvedCount: Int.optional(),
+          totalCount: Int.optional(),
+        }).passthrough(),
+      )
+      .optional(),
+  })
+  .passthrough();

--- a/src/lib/schema/errors.js
+++ b/src/lib/schema/errors.js
@@ -1,0 +1,12 @@
+export class ApiSchemaError extends Error {
+  /**
+   * @param {{ context: string, issues: any[] }} param0
+   */
+  constructor({ context, issues }) {
+    super("서버 응답 형식이 예상과 달라요. 잠시 후 다시 시도해주세요.");
+    this.name = "ApiSchemaError";
+    this.code = "API_SCHEMA_INVALID";
+    this.context = context;
+    this.issues = issues;
+  }
+}

--- a/src/lib/schema/group.schema.js
+++ b/src/lib/schema/group.schema.js
@@ -1,4 +1,11 @@
-import { z, Id, Int, Visibility, requireOneOf, DateTimeString } from "./primitives";
+import {
+  z,
+  Id,
+  Int,
+  Visibility,
+  requireOneOf,
+  DateTimeString,
+} from "./primitives";
 
 /**
  * Group summary returned from GET /groups
@@ -42,7 +49,7 @@ export const ApiGroupDetailSchema = z
     updatedAt: DateTimeString.optional(),
   })
   .passthrough()
-  .refine(requireOneOf(["title", "name"], "Group must have title or name"), {
+  .refine(requireOneOf(["title", "name"]), {
     message: "Group must have title or name",
     path: ["title"],
   });
@@ -60,13 +67,9 @@ export const ApiGroupUserSchema = z
     role: z.string().optional(),
   })
   .passthrough()
-  .refine(requireOneOf(["userId", "id"], "User must have id"), {
+  .refine(requireOneOf(["userId", "id"]), {
     message: "User must have id",
     path: ["id"],
-  })
-  .transform((u) => ({
-    ...u,
-    userId: u.userId ?? u.id,
-  }));
+  });
 
 export const ApiGroupUserListSchema = z.array(ApiGroupUserSchema);

--- a/src/lib/schema/group.schema.js
+++ b/src/lib/schema/group.schema.js
@@ -1,0 +1,72 @@
+import { z, Id, Int, Visibility, requireOneOf, DateTimeString } from "./primitives";
+
+/**
+ * Group summary returned from GET /groups
+ * (fields based on src/services/groupService.js mapping)
+ */
+export const ApiGroupSummarySchema = z
+  .object({
+    id: Id,
+    title: z.string().min(1),
+    ownerId: Id.nullable().optional(),
+    visibility: Visibility.optional(),
+    memberCount: Int.optional(),
+    groupRole: z.string().nullable().optional(),
+    description: z.string().optional(),
+    createdAt: DateTimeString.optional(),
+    updatedAt: DateTimeString.optional(),
+  })
+  .passthrough();
+
+export const ApiGroupSummaryListSchema = z.array(ApiGroupSummarySchema);
+
+/**
+ * Group detail returned from GET /groups/{id}/detail
+ */
+export const ApiGroupDetailSchema = z
+  .object({
+    id: Id,
+    title: z.string().optional(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+    ownerId: Id.nullable().optional(),
+
+    managers: z.array(Id).optional(),
+    managerIds: z.array(Id).optional(),
+
+    members: z.array(Id).optional(),
+    memberIds: z.array(Id).optional(),
+
+    visibility: Visibility.optional(),
+    createdAt: DateTimeString.optional(),
+    updatedAt: DateTimeString.optional(),
+  })
+  .passthrough()
+  .refine(requireOneOf(["title", "name"], "Group must have title or name"), {
+    message: "Group must have title or name",
+    path: ["title"],
+  });
+
+/**
+ * GroupUserDto returned from GET /groups/{id}/users
+ * (minimal: keep permissive; enforce IDs)
+ */
+export const ApiGroupUserSchema = z
+  .object({
+    userId: Id.optional(),
+    id: Id.optional(),
+    username: z.string().optional(),
+    nickname: z.string().optional(),
+    role: z.string().optional(),
+  })
+  .passthrough()
+  .refine(requireOneOf(["userId", "id"], "User must have id"), {
+    message: "User must have id",
+    path: ["id"],
+  })
+  .transform((u) => ({
+    ...u,
+    userId: u.userId ?? u.id,
+  }));
+
+export const ApiGroupUserListSchema = z.array(ApiGroupUserSchema);

--- a/src/lib/schema/group.schema.js
+++ b/src/lib/schema/group.schema.js
@@ -67,9 +67,10 @@ export const ApiGroupUserSchema = z
     role: z.string().optional(),
   })
   .passthrough()
-  .refine(requireOneOf(["userId", "id"]), {
+  .transform((u) => ({ ...u, userId: u.userId ?? u.id }))
+  .refine((u) => u.userId != null, {
     message: "User must have id",
-    path: ["id"],
+    path: ["userId"],
   });
 
 export const ApiGroupUserListSchema = z.array(ApiGroupUserSchema);

--- a/src/lib/schema/primitives.js
+++ b/src/lib/schema/primitives.js
@@ -6,10 +6,9 @@ import { z } from "zod";
  *   while still failing on obviously wrong shapes.
  */
 
-export const Id = z.union([
-  z.number(),
-  z.string().regex(/^\d+$/),
-]).transform((v) => Number(v));
+export const Id = z
+  .union([z.number(), z.string().regex(/^\d+$/)])
+  .transform((v) => Number(v));
 
 export const Int = z.coerce.number().int();
 export const Bool = z.coerce.boolean();
@@ -23,8 +22,8 @@ export const StringArray = z.array(z.string());
 export const Visibility = z.enum(["PUBLIC", "PRIVATE"]);
 
 // Helper: require at least one of the given keys to be present (non-null/undefined).
-export function requireOneOf(keys, message) {
-  return (obj) => keys.some((k) => obj?.[k] != null) || message || `Expected one of: ${keys.join(", ")}`;
+export function requireOneOf(keys) {
+  return (obj) => keys.some((k) => obj?.[k] != null);
 }
 
 export { z };

--- a/src/lib/schema/primitives.js
+++ b/src/lib/schema/primitives.js
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * Primitive schemas shared across API contracts.
+ * - Prefer permissive-but-typed parsing (coerce) for IDs/numbers,
+ *   while still failing on obviously wrong shapes.
+ */
+
+export const Id = z.union([
+  z.number(),
+  z.string().regex(/^\d+$/),
+]).transform((v) => Number(v));
+
+export const Int = z.coerce.number().int();
+export const Bool = z.coerce.boolean();
+
+// ISO-ish date/time strings (keep permissive: backend formats may vary)
+export const DateTimeString = z.string().min(1);
+export const NullableDateTimeString = DateTimeString.nullable();
+
+export const StringArray = z.array(z.string());
+
+export const Visibility = z.enum(["PUBLIC", "PRIVATE"]);
+
+// Helper: require at least one of the given keys to be present (non-null/undefined).
+export function requireOneOf(keys, message) {
+  return (obj) => keys.some((k) => obj?.[k] != null) || message || `Expected one of: ${keys.join(", ")}`;
+}
+
+export { z };

--- a/src/lib/schema/problem.schema.js
+++ b/src/lib/schema/problem.schema.js
@@ -1,0 +1,52 @@
+import { z, Id, Int, StringArray, requireOneOf } from "./primitives";
+
+/**
+ * Raw problem DTOs used by problemService.normalizeProblem().
+ * Accepts both snake_case and camelCase fields.
+ */
+export const ApiProblemSchema = z
+  .object({
+    id: Id.optional(),
+    problemId: Id.optional(),
+
+    title: z.string().optional(),
+    name: z.string().optional(),
+
+    difficulty: Int.optional(),
+
+    tags: StringArray.optional(),
+
+    acceptedUserCount: Int.optional(),
+    accepted_user_count: Int.optional(),
+
+    registeredAt: z.string().optional(),
+    registered_before: z.string().optional(),
+    updatedAt: z.string().optional(),
+    createdAt: z.string().optional(),
+
+    reviewCount: Int.optional(),
+    review_count: Int.optional(),
+    reviewCnt: Int.optional(),
+  })
+  .passthrough()
+  .refine(requireOneOf(["id", "problemId"], "Problem must have id"), {
+    message: "Problem must have id",
+    path: ["id"],
+  });
+
+export const ApiProblemListSchema = z.array(ApiProblemSchema);
+
+/**
+ * Normalized problem shape used in UI (return value of normalizeProblem()).
+ * Keeping this helps ensure services don't leak inconsistent models.
+ */
+export const FrontProblemSchema = z.object({
+  id: Id,
+  title: z.string(),
+  difficulty: z.string(), // label (e.g., "Gold III" / "Unrated")
+  tags: z.array(z.string()),
+  acceptedUserCount: Int,
+  registeredAt: z.string().nullable(),
+  reviewCount: Int.optional(),
+});
+export const FrontProblemListSchema = z.array(FrontProblemSchema);

--- a/src/lib/schema/problem.schema.js
+++ b/src/lib/schema/problem.schema.js
@@ -29,7 +29,7 @@ export const ApiProblemSchema = z
     reviewCnt: Int.optional(),
   })
   .passthrough()
-  .refine(requireOneOf(["id", "problemId"], "Problem must have id"), {
+  .refine(requireOneOf(["id", "problemId"]), {
     message: "Problem must have id",
     path: ["id"],
   });

--- a/src/lib/schema/problem.schema.js
+++ b/src/lib/schema/problem.schema.js
@@ -41,12 +41,12 @@ export const ApiProblemListSchema = z.array(ApiProblemSchema);
  * Keeping this helps ensure services don't leak inconsistent models.
  */
 export const FrontProblemSchema = z.object({
-  id: Id,
+  id: z.number().int(),
   title: z.string(),
   difficulty: z.string(), // label (e.g., "Gold III" / "Unrated")
   tags: z.array(z.string()),
-  acceptedUserCount: Int,
+  acceptedUserCount: z.number().int(),
   registeredAt: z.string().nullable(),
-  reviewCount: Int.optional(),
+  reviewCount: z.number().int().optional(),
 });
 export const FrontProblemListSchema = z.array(FrontProblemSchema);

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -9,6 +9,13 @@ import {
 } from "@/mocks/board.mock";
 import { mockGetBoardUserStatus } from "@/mocks/boardUserStatus.mock";
 
+import { assertSchema } from "@/lib/schema/assertSchema";
+import {
+  ApiBoardDetailSchema,
+  ApiBoardProgressSchema,
+  ApiBoardSummaryListSchema,
+} from "@/lib/schema/board.schema";
+
 const USE_MOCK_BOARD = apiMode.board === "mock";
 const USE_MOCK_BOARD_STATUS = apiMode.boardStatus === "mock";
 
@@ -121,7 +128,11 @@ export const boardService = {
       return mockFetchBoards(groupId);
     }
 
-    const apiBoards = await boardApi.fetchBoards(groupId, options);
+    const apiBoards = assertSchema(
+      ApiBoardSummaryListSchema,
+      await boardApi.fetchBoards(groupId, options),
+      "boardApi.fetchBoards",
+    );
     return apiBoards.map((b) => mapBoardSummaryFromApi(b, Number(groupId)));
   },
 
@@ -130,7 +141,11 @@ export const boardService = {
       return mockFetchBoardById(boardId);
     }
 
-    const apiBoard = await boardApi.fetchBoardById(groupId, boardId);
+    const apiBoard = assertSchema(
+      ApiBoardDetailSchema,
+      await boardApi.fetchBoardById(groupId, boardId),
+      "boardApi.fetchBoardById",
+    );
     return mapBoardDetailFromApi(apiBoard);
   },
 
@@ -173,11 +188,15 @@ export const boardService = {
       return mockGetBoardUserStatus(groupId, boardId);
     }
 
-    const apiRes = await boardApi.getBoardUserStatus({
-      groupId,
-      boardId,
-      requesterId,
-    });
+    const apiRes = assertSchema(
+      ApiBoardProgressSchema,
+      await boardApi.getBoardUserStatus({
+        groupId,
+        boardId,
+        requesterId,
+      }),
+      "boardApi.getBoardUserStatus",
+    );
     return mapBoardProgressFromApi(apiRes);
   },
 };

--- a/src/services/groupService.js
+++ b/src/services/groupService.js
@@ -9,6 +9,13 @@ import {
   mockChangeGroupOwner,
 } from "@/mocks/group.mock";
 
+import { assertSchema } from "@/lib/schema/assertSchema";
+import {
+  ApiGroupDetailSchema,
+  ApiGroupSummaryListSchema,
+  ApiGroupUserListSchema,
+} from "@/lib/schema/group.schema";
+
 const USE_MOCK_GROUP = apiMode.group === "mock";
 
 const toNumArr = (arr) => (Array.isArray(arr) ? arr.map((v) => Number(v)) : []);
@@ -48,7 +55,11 @@ export const groupService = {
     }
 
     // GroupSummaryResponse[]
-    const list = await groupApi.fetchGroups({ requesterId, name });
+    const list = assertSchema(
+      ApiGroupSummaryListSchema,
+      await groupApi.fetchGroups({ requesterId, name }),
+      "groupApi.fetchGroups",
+    );
 
     // FE에서 쓰기 좋은 형태로 매핑
     return list.map((g) => ({
@@ -144,7 +155,11 @@ export const groupService = {
       );
     }
 
-    const apiGroup = await groupApi.fetchGroupById(groupId, { requesterId });
+    const apiGroup = assertSchema(
+      ApiGroupDetailSchema,
+      await groupApi.fetchGroupById(groupId, { requesterId }),
+      "groupApi.fetchGroupById",
+    );
     return mapGroupDetailFromApi(apiGroup);
   },
 
@@ -190,7 +205,11 @@ export const groupService = {
     if (result && typeof result === "object" && "success" in result) {
       if (!result.success) throw new Error("그룹 수정에 실패했습니다.");
 
-      const updated = await groupApi.fetchGroupById(groupId, { requesterId });
+      const updated = assertSchema(
+        ApiGroupDetailSchema,
+        await groupApi.fetchGroupById(groupId, { requesterId }),
+        "groupApi.fetchGroupById",
+      );
       return mapGroupDetailFromApi(updated);
     }
 
@@ -224,7 +243,11 @@ export const groupService = {
         throw new Error("소유자 변경에 실패했습니다.");
       }
 
-      const updated = await groupApi.fetchGroupById(groupId, { requesterId });
+      const updated = assertSchema(
+        ApiGroupDetailSchema,
+        await groupApi.fetchGroupById(groupId, { requesterId }),
+        "groupApi.fetchGroupById",
+      );
       return mapGroupDetailFromApi(updated);
     }
 
@@ -250,10 +273,14 @@ export const groupService = {
       );
     }
 
-    const list = await groupApi.fetchGroupUsers(groupId, { requesterId });
+    const list = assertSchema(
+      ApiGroupUserListSchema,
+      await groupApi.fetchGroupUsers(groupId, { requesterId }),
+      "groupApi.fetchGroupUsers",
+    );
 
     return (list || []).map((u) => ({
-      id: Number(u.userId),
+      id: Number(u.userId ?? u.id),
       name: u.username,
       nickname: u.username, // email 표시로 UI 개선 가능
       role: u.role, // OWNER | MANAGER | MEMBER

--- a/src/services/problemService.js
+++ b/src/services/problemService.js
@@ -6,7 +6,7 @@ import {
   postBoard as mockPostBoard,
 } from "@/mocks/problem.mock";
 
-import { assertSchema } from "@/lib/schema/assertSchema";
+import { assertSchema, isDevEnv } from "@/lib/schema/assertSchema";
 import {
   ApiProblemListSchema,
   FrontProblemListSchema,
@@ -108,14 +108,7 @@ function getRandomSubset(arr, count) {
 }
 
 function assertSchemaDev(schema, data, context) {
-  const isDev =
-    typeof import.meta !== "undefined" &&
-    import.meta.env &&
-    (import.meta.env.DEV ||
-      import.meta.env.MODE === "test" ||
-      import.meta.env.MODE === "development");
-
-  return isDev ? assertSchema(schema, data, context) : data;
+  return isDevEnv() ? assertSchema(schema, data, context) : data;
 }
 
 export const problemService = {

--- a/src/services/problemService.js
+++ b/src/services/problemService.js
@@ -107,6 +107,17 @@ function getRandomSubset(arr, count) {
   return copy.slice(0, count);
 }
 
+function assertSchemaDev(schema, data, context) {
+  const isDev =
+    typeof import.meta !== "undefined" &&
+    import.meta.env &&
+    (import.meta.env.DEV ||
+      import.meta.env.MODE === "test" ||
+      import.meta.env.MODE === "development");
+
+  return isDev ? assertSchema(schema, data, context) : data;
+}
+
 export const problemService = {
   /**
    * 문제 번호로 검색 (mock/real 공통 인터페이스)
@@ -120,8 +131,14 @@ export const problemService = {
       "problemApi.searchByNumber",
     );
 
+    // 1) raw api response validate (always)
+    // 2) normalized frontend model validate (DEV/TEST only)
+    //
+    // Why double validation?
+    // - Catch backend contract drift early (API schema)
+    // - Catch internal mapping regression (frontend schema) without shipping runtime overhead to prod
     const normalized = list.map((p) => normalizeProblem(p));
-    return assertSchema(
+    return assertSchemaDev(
       FrontProblemListSchema,
       normalized,
       "problemService.normalizeProblem",
@@ -273,8 +290,14 @@ export const problemService = {
       "problemApi.filterProblems",
     );
 
+    // 1) raw api response validate (always)
+    // 2) normalized frontend model validate (DEV/TEST only)
+    //
+    // Why double validation?
+    // - Catch backend contract drift early (API schema)
+    // - Catch internal mapping regression (frontend schema) without shipping runtime overhead to prod
     const normalized = apiList.map((p) => normalizeProblem(p));
-    const normalizedSafe = assertSchema(
+    const normalizedSafe = assertSchemaDev(
       FrontProblemListSchema,
       normalized,
       "problemService.normalizeProblem",

--- a/src/services/problemService.js
+++ b/src/services/problemService.js
@@ -5,6 +5,12 @@ import {
   searchWithConditions as mockSearchWithConditions,
   postBoard as mockPostBoard,
 } from "@/mocks/problem.mock";
+
+import { assertSchema } from "@/lib/schema/assertSchema";
+import {
+  ApiProblemListSchema,
+  FrontProblemListSchema,
+} from "@/lib/schema/problem.schema";
 import { difficultyOptions } from "@/data/difficultyOptions";
 
 const USE_MOCK_PROBLEM = apiMode.problem === "mock";
@@ -108,8 +114,18 @@ export const problemService = {
    */
   async searchByNumber(problemNo) {
     if (USE_MOCK_PROBLEM) return mockSearchByNumber(problemNo);
-    const list = await problemApi.searchByNumber(problemNo);
-    return Array.isArray(list) ? list.map((p) => normalizeProblem(p)) : [];
+    const list = assertSchema(
+      ApiProblemListSchema,
+      await problemApi.searchByNumber(problemNo),
+      "problemApi.searchByNumber",
+    );
+
+    const normalized = list.map((p) => normalizeProblem(p));
+    return assertSchema(
+      FrontProblemListSchema,
+      normalized,
+      "problemService.normalizeProblem",
+    );
   },
 
   /**
@@ -251,14 +267,23 @@ export const problemService = {
       option: mergedOption,
     });
 
-    const normalized = Array.isArray(rawList)
-      ? rawList.map((p) => normalizeProblem(p))
-      : [];
+    const apiList = assertSchema(
+      ApiProblemListSchema,
+      rawList,
+      "problemApi.filterProblems",
+    );
+
+    const normalized = apiList.map((p) => normalizeProblem(p));
+    const normalizedSafe = assertSchema(
+      FrontProblemListSchema,
+      normalized,
+      "problemService.normalizeProblem",
+    );
 
     const dateLimit = registeredBefore ?? beforeDate;
-    if (!dateLimit) return normalized;
+    if (!dateLimit) return normalizedSafe;
 
-    return normalized.filter(
+    return normalizedSafe.filter(
       (p) => p.registeredAt && p.registeredAt <= dateLimit,
     );
   },

--- a/src/services/problemService.js
+++ b/src/services/problemService.js
@@ -64,6 +64,11 @@ function toFiniteNumber(v) {
   return Number.isFinite(n) ? n : undefined;
 }
 
+function toFiniteInt(v, fallback = undefined) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : fallback;
+}
+
 /**
  * 서버/목 스펙이 달라도 UI가 쓰는 공통 모델로 정규화
  * UI에서 사용하는 필드:
@@ -83,7 +88,7 @@ function normalizeProblem(p) {
   );
 
   return {
-    id: p.id ?? p.problemId,
+    id: toFiniteInt(p.id ?? p.problemId, 0),
     title: p.title ?? p.name ?? "",
     difficulty: difficultyIndexToLabel(p.difficulty),
     tags: Array.isArray(p.tags) ? p.tags : [],

--- a/src/services/problemService.js
+++ b/src/services/problemService.js
@@ -92,7 +92,10 @@ function normalizeProblem(p) {
     title: p.title ?? p.name ?? "",
     difficulty: difficultyIndexToLabel(p.difficulty),
     tags: Array.isArray(p.tags) ? p.tags : [],
-    acceptedUserCount: p.acceptedUserCount ?? p.accepted_user_count ?? 0,
+    acceptedUserCount: toFiniteInt(
+      p.acceptedUserCount ?? p.accepted_user_count,
+      0,
+    ),
     registeredAt,
     reviewCount, // undefined 가능
   };

--- a/tests/contract.schema.spec.js
+++ b/tests/contract.schema.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { assertSchema } from "@/lib/schema/assertSchema";
 import { ApiGroupDetailSchema } from "@/lib/schema/group.schema";
+import { ApiSchemaError } from "@/lib/schema/errors";
 
 describe("API contract schemas", () => {
   it("parses GroupDetail with title + ids", () => {
@@ -20,9 +21,23 @@ describe("API contract schemas", () => {
     expect(parsed.ownerId).toBe(1);
   });
 
-  it("throws ApiSchemaError when required fields are missing", () => {
-    expect(() =>
-      assertSchema(ApiGroupDetailSchema, { title: "x" }, "test"),
-    ).toThrowError();
+  it("throws ApiSchemaError with context/issues when required fields are missing", () => {
+    try {
+      assertSchema(
+        ApiGroupDetailSchema,
+        { description: "x" },
+        "group.detail.test",
+      );
+      throw new Error("Expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiSchemaError);
+      expect(err.code).toBe("API_SCHEMA_INVALID");
+      expect(err.context).toBe("group.detail.test");
+      expect(Array.isArray(err.issues)).toBe(true);
+      expect(err.issues.length).toBeGreaterThan(0);
+      expect(err.issues[0]).toHaveProperty("path");
+      expect(err.issues[0]).toHaveProperty("code");
+      expect(err.issues[0]).toHaveProperty("message");
+    }
   });
 });

--- a/tests/contract.schema.spec.js
+++ b/tests/contract.schema.spec.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { assertSchema } from "@/lib/schema/assertSchema";
+import { ApiGroupDetailSchema } from "@/lib/schema/group.schema";
+
+describe("API contract schemas", () => {
+  it("parses GroupDetail with title + ids", () => {
+    const input = {
+      id: "10",
+      title: "Algo Study",
+      ownerId: 1,
+      managers: ["1", 2],
+      members: [1, 2, 3],
+      visibility: "PRIVATE",
+      createdAt: "2025-01-01T00:00:00",
+      updatedAt: "2025-01-02T00:00:00",
+    };
+
+    const parsed = assertSchema(ApiGroupDetailSchema, input, "test");
+    expect(parsed.id).toBe(10);
+    expect(parsed.ownerId).toBe(1);
+  });
+
+  it("throws ApiSchemaError when required fields are missing", () => {
+    expect(() =>
+      assertSchema(ApiGroupDetailSchema, { title: "x" }, "test"),
+    ).toThrowError();
+  });
+});


### PR DESCRIPTION
이슈 번호: https://github.com/cheonggangsan/BlueStrongMountain_frontend/issues/83
---
## ✅ 구현 내용
- 서비스 경계에서 API 응답을 Zod 스키마로 검증하여 **계약 불일치를 조기 탐지**
- 계약 불일치 시 `ApiSchemaError(API_SCHEMA_INVALID)`로 **fail-fast**
- DEV 환경에서 context/issues/data 로그로 디버깅 가능

## 📂 변경 모듈
- deps
  - `package.json` : `zod` 추가 (lockfile은 로컬에서 `npm i`로 갱신 필요)
- 신규
  - `src/lib/schema/primitives.js`
  - `src/lib/schema/errors.js`
  - `src/lib/schema/assertSchema.js`
  - `src/lib/schema/group.schema.js`
  - `src/lib/schema/board.schema.js`
  - `src/lib/schema/problem.schema.js`
  - `tests/contract.schema.spec.js`
- 수정
  - `src/services/groupService.js`
  - `src/services/boardService.js`
  - `src/services/problemService.js`

## 🧪 테스트 / 시나리오
로컬에서 아래 실행:
- `npm i`
- `npm test`
- `npm run lint`

검증 포인트:
- 정상 응답: 기존 화면 플로우 동일(그룹/보드/문제 검색)
- 비정상 응답(필드 누락 등): `ApiSchemaError` 발생 + DEV 콘솔에 상세 로그 출력

## 💡 기타
- 스키마는 “너무 엄격하지 않되 핵심 필드(id/title 등)는 강제” 전략으로 시작
- 향후 PR에서:
  - 스키마 엄격도 강화(실제 백엔드 응답 샘플 기반)
  - 전역 에러 핸들러/토스트 연결(PR4)로 사용자 UX 개선 가능

## 체크리스트
- [x] `package-lock.json` 갱신/커밋 (CI에서 install 안정성 위해 권장)
- [x] lint/test/build 통과
- [x] 서비스별 검증 context 문자열이 엔드포인트 단위로 명확함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 보드·그룹·문제 관련 API 응답을 위한 런타임 스키마 추가로 데이터 무결성 및 반환 형식 표준화
  * ID·필드 표현의 유연성 및 일관성 개선(숫자/문자 ID, 선택적 필드 통합)
  * 개발환경에서의 상세 검증 로깅 및 컨텍스트 포함 구조화된 검증 오류 반환

* **Chores**
  * 런타임 검증용 라이브러리(zod) 의존성 추가

* **Tests**
  * 스키마 파싱과 오류 동작을 검증하는 계약 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->