### PR TITLE
[BSM-85] refactor: introduce TanStack Vue Query cache layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vue-problem-board",
       "version": "0.0.1",
       "dependencies": {
+        "@tanstack/vue-query": "^5.92.5",
         "axios": "^1.13.2",
         "flowbite": "^2.5.2",
         "flowbite-vue": "^0.2.2",
@@ -1945,6 +1946,83 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "license": "MIT",
+      "dependencies": {
+        "remove-accents": "0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
+      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-query": {
+      "version": "5.92.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-query/-/vue-query-5.92.5.tgz",
+      "integrity": "sha512-wbJ820OdPbmyKqrs/FW3n/4fScji63d2aAQqTl54ex9UolJwJdrEqDmSGyc5R5orgs3OlWVlF5UsK+/7wLxgzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.19.4",
+        "@tanstack/query-core": "5.90.16",
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.2",
+        "vue": "^2.6.0 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/vue-query/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -6027,6 +6105,12 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@tanstack/vue-query": "^5.92.5",
     "axios": "^1.13.2",
     "flowbite": "^2.5.2",
     "flowbite-vue": "^0.2.2",

--- a/src/data/authStore.js
+++ b/src/data/authStore.js
@@ -1,5 +1,6 @@
 import { reactive, computed, readonly } from "vue";
 import { authService } from "@/services/authService";
+import { queryClient } from "@/lib/query/queryClient";
 import { USER_STORAGE_KEY, LOGOUT_EVENT } from "../constants/auth";
 
 const state = reactive({
@@ -114,6 +115,12 @@ async function logout() {
   } catch (err) {
     console.error("[authStore] logout error:", err);
   } finally {
+    try {
+      queryClient.clear();
+    } catch (err) {
+      console.warn("[authStore] queryClient.clear failed:", err);
+    }
+
     clearUser();
     state.initialized = true;
     state.isLoading = false;

--- a/src/data/boardStore.js
+++ b/src/data/boardStore.js
@@ -1,5 +1,7 @@
 import { ref } from "vue";
 import { boardService } from "../services/boardService";
+import { queryClient } from "@/lib/query/queryClient";
+import { boardKeys } from "@/lib/query/queryKeys";
 
 export const boards = ref([]);
 
@@ -7,7 +9,11 @@ export const boards = ref([]);
  * 그룹 ID에 해당하는 보드 목록을 가져옵니다.
  */
 export async function fetchBoards(groupId) {
-  const list = await boardService.fetchBoards(groupId);
+  const list = await queryClient.fetchQuery({
+    queryKey: boardKeys.list(groupId),
+    queryFn: () => boardService.fetchBoards(groupId),
+  });
+
   boards.value = [...list];
   return boards.value;
 }
@@ -25,6 +31,12 @@ export async function fetchBoards(groupId) {
  */
 export async function addBoard(board) {
   await boardService.createBoard(board);
+
+  if (board?.groupId) {
+    queryClient.invalidateQueries({ queryKey: boardKeys.list(board.groupId) });
+  } else {
+    queryClient.invalidateQueries({ queryKey: boardKeys.all });
+  }
 }
 
 /**
@@ -40,6 +52,9 @@ export async function deleteBoard({ groupId, boardId, requesterId }) {
 
   const numericId = Number(boardId);
   boards.value = boards.value.filter((b) => b.id !== numericId);
+
+  queryClient.invalidateQueries({ queryKey: boardKeys.list(groupId) });
+  queryClient.removeQueries({ queryKey: boardKeys.detail(groupId, numericId) });
 }
 
 /**
@@ -66,6 +81,17 @@ export async function updateBoard(board) {
       ...board,
     });
   }
+
+  if (board?.groupId) {
+    queryClient.invalidateQueries({ queryKey: boardKeys.list(board.groupId) });
+  } else {
+    queryClient.invalidateQueries({ queryKey: boardKeys.all });
+  }
+  if (board?.groupId && board?.id) {
+    queryClient.invalidateQueries({
+      queryKey: boardKeys.detail(board.groupId, board.id),
+    });
+  }
 }
 
 /**
@@ -75,7 +101,10 @@ export async function updateBoard(board) {
  *  - boardId: number
  */
 export async function fetchBoardById(groupId, boardId) {
-  return boardService.fetchBoardById(groupId, boardId);
+  return queryClient.fetchQuery({
+    queryKey: boardKeys.detail(groupId, boardId),
+    queryFn: () => boardService.fetchBoardById(groupId, boardId),
+  });
 }
 
 /**
@@ -86,5 +115,9 @@ export async function fetchBoardById(groupId, boardId) {
  *  - requesterId: number
  */
 export async function getBoardUserStatus({ groupId, boardId, requesterId }) {
-  return boardService.getBoardUserStatus({ groupId, boardId, requesterId });
+  return queryClient.fetchQuery({
+    queryKey: boardKeys.userStatus(groupId, boardId, requesterId),
+    queryFn: () =>
+      boardService.getBoardUserStatus({ groupId, boardId, requesterId }),
+  });
 }

--- a/src/data/groupStore.js
+++ b/src/data/groupStore.js
@@ -1,5 +1,7 @@
 import { ref } from "vue";
 import { groupService } from "@/services/groupService";
+import { queryClient } from "@/lib/query/queryClient";
+import { groupKeys } from "@/lib/query/queryKeys";
 
 export const groups = ref([]);
 
@@ -8,7 +10,11 @@ export const groups = ref([]);
  * @param {{ requesterId?: number, name?: string }} options
  */
 export async function fetchGroups(options = {}) {
-  const list = await groupService.fetchGroups(options);
+  const list = await queryClient.fetchQuery({
+    queryKey: groupKeys.list(options),
+    queryFn: () => groupService.fetchGroups(options),
+  });
+
   groups.value = [...list];
   return groups.value;
 }
@@ -21,6 +27,14 @@ export async function leaveGroup(groupId, options = {}) {
   const numericId = Number(groupId);
 
   await groupService.leaveGroup(numericId, options);
+
+  queryClient.invalidateQueries({ queryKey: groupKeys.all });
+  queryClient.removeQueries({
+    queryKey: groupKeys.detail(numericId, options?.requesterId),
+  });
+  queryClient.removeQueries({
+    queryKey: groupKeys.users(numericId, options?.requesterId),
+  });
 
   // 로컬 상태에서도 제거
   groups.value = groups.value.filter((g) => g.id !== numericId);
@@ -39,6 +53,8 @@ export async function leaveGroup(groupId, options = {}) {
 export async function createGroup(payload) {
   const newGroup = await groupService.createGroup(payload);
 
+  queryClient.invalidateQueries({ queryKey: groupKeys.all });
+
   if (newGroup && typeof newGroup === "object" && "id" in newGroup) {
     // mock 모드일 때만 동작 (newGroup가 실제 그룹 객체인 경우)
     groups.value = [newGroup, ...groups.value];
@@ -51,7 +67,23 @@ export async function createGroup(payload) {
  * 그룹 하나 상세 조회
  */
 export async function fetchGroupById(groupId, options = {}) {
-  return groupService.fetchGroupById(groupId, options);
+  const requesterId = options?.requesterId;
+
+  const group = await queryClient.fetchQuery({
+    queryKey: groupKeys.detail(groupId, requesterId),
+    queryFn: () => groupService.fetchGroupById(groupId, options),
+  });
+
+  // If we already have a list in-memory, merge detail to keep UI consistent.
+  if (group && typeof group === "object" && "id" in group) {
+    const numericId = Number(group.id);
+    const index = groups.value.findIndex((g) => g.id === numericId);
+    if (index !== -1) {
+      groups.value.splice(index, 1, { ...groups.value[index], ...group });
+    }
+  }
+
+  return group;
 }
 
 /**
@@ -59,6 +91,14 @@ export async function fetchGroupById(groupId, options = {}) {
  */
 export async function updateGroup(groupId, payload) {
   const updated = await groupService.updateGroup(groupId, payload);
+
+  queryClient.invalidateQueries({ queryKey: groupKeys.all });
+  if (payload?.requesterId) {
+    queryClient.setQueryData(
+      groupKeys.detail(groupId, payload.requesterId),
+      updated,
+    );
+  }
 
   // mock 모드(그룹 객체 반환) 일 때만 state 반영
   if (updated && typeof updated === "object" && "id" in updated) {
@@ -82,6 +122,9 @@ export async function changeGroupOwner(groupId, { requesterId, newOwnerId }) {
     newOwnerId,
   });
 
+  queryClient.invalidateQueries({ queryKey: groupKeys.all });
+  queryClient.setQueryData(groupKeys.detail(groupId, requesterId), updated);
+
   if (updated && typeof updated === "object" && "id" in updated) {
     const numericId = Number(groupId);
     const index = groups.value.findIndex((g) => g.id === numericId);
@@ -98,5 +141,10 @@ export async function changeGroupOwner(groupId, { requesterId, newOwnerId }) {
  * 그룹 사용자 목록 조회
  */
 export async function fetchGroupUsers(groupId, options = {}) {
-  return groupService.fetchGroupUsers(groupId, options);
+  const requesterId = options?.requesterId;
+
+  return queryClient.fetchQuery({
+    queryKey: groupKeys.users(groupId, requesterId),
+    queryFn: () => groupService.fetchGroupUsers(groupId, options),
+  });
 }

--- a/src/lib/query/queryClient.js
+++ b/src/lib/query/queryClient.js
@@ -1,0 +1,30 @@
+import { QueryClient } from "@tanstack/vue-query";
+
+/**
+ * Global TanStack Query client.
+ *
+ * Goals:
+ * - Deduplicate requests across router guards + pages
+ * - Provide a single cache for "server state"
+ * - Keep current store APIs working (stores can call queryClient.fetchQuery)
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Avoid repeated refetch during quick navigation.
+      staleTime: 30_000, // 30s
+      // How long unused cache stays in memory.
+      gcTime: 5 * 60_000, // 5m
+
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+
+      // Retry only for likely-transient failures. Axios errors provide `response.status`.
+      retry: (failureCount, error) => {
+        const status = error?.response?.status;
+        if (status && status >= 400 && status < 500) return false;
+        return failureCount < 2;
+      },
+    },
+  },
+});

--- a/src/lib/query/queryKeys.js
+++ b/src/lib/query/queryKeys.js
@@ -1,0 +1,46 @@
+/**
+ * Query keys factory (stable, serializable).
+ *
+ * Tip: Always include requesterId when the server response can differ per user.
+ */
+export const groupKeys = {
+  all: ["groups"],
+  list: (options = {}) => [
+    "groups",
+    "list",
+    {
+      requesterId: options.requesterId ? Number(options.requesterId) : null,
+      name: options.name ?? "",
+    },
+  ],
+  detail: (groupId, requesterId) => [
+    "groups",
+    "detail",
+    Number(groupId),
+    requesterId ? Number(requesterId) : null,
+  ],
+  users: (groupId, requesterId) => [
+    "groups",
+    "users",
+    Number(groupId),
+    requesterId ? Number(requesterId) : null,
+  ],
+};
+
+export const boardKeys = {
+  all: ["boards"],
+  list: (groupId) => ["boards", "list", Number(groupId)],
+  detail: (groupId, boardId) => [
+    "boards",
+    "detail",
+    Number(groupId),
+    Number(boardId),
+  ],
+  userStatus: (groupId, boardId, requesterId) => [
+    "boards",
+    "userStatus",
+    Number(groupId),
+    Number(boardId),
+    requesterId ? Number(requesterId) : null,
+  ],
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,16 @@
 import { createApp } from "vue";
+import { VueQueryPlugin } from "@tanstack/vue-query";
+
 import App from "./App.vue";
 import "./styles/main.scss";
 import "flowbite";
 import router from "./router";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 
+import { queryClient } from "@/lib/query/queryClient";
+
 const app = createApp(App);
+
+app.use(VueQueryPlugin, { queryClient });
 app.use(router);
 app.mount("#app");


### PR DESCRIPTION
## ✅ 구현 내용
서버 상태(그룹/보드 등)의 중복 fetch 및 분산된 로딩/에러 처리 문제를 줄이기 위해 **TanStack Vue Query 기반 캐시 레이어**를 도입했습니다.

핵심은 **“화면/가드 어디서 fetch 하든 동일 queryKey면 캐시를 재사용”** 하도록 만들어
- 중복 호출을 제거(dedup)
- 데이터 최신화 정책을 고정(invalidate/remove)
- 로그아웃 시 캐시 초기화로 세션 간 데이터 누출 방지
하는 것입니다.

### 설계 결정 / 트레이드오프
이번 PR은 화면을 `useQuery/useMutation`로 전면 전환하지 않고,
**기존 store 인터페이스를 유지**한 채 내부를 `queryClient.fetchQuery`로 래핑했습니다.

- 장점: 변경 범위 최소화, 기존 컴포넌트 코드 유지
- 단점: Vue Query의 훅 기반 패턴(useQuery)을 화면에서 직접 활용하진 못함  
  → 후속 PR에서 화면 단 점진 전환 가능

---

## 📂 변경 모듈
- `src/main.js`
  - VueQueryPlugin/QueryClient 등록
- `src/lib/query/queryClient.*`
  - QueryClient 싱글톤(전역 캐시)
- `src/lib/query/queryKeys.*`
  - 리소스별 queryKey 팩토리(키 안정화)
- `src/data/groupStore.*`
  - fetch 계열을 `queryClient.fetchQuery` 기반으로 전환
  - create/update/leave/owner-change 이후 invalidate 정책 적용
- `src/data/boardStore.*`
  - fetch 계열을 `queryClient.fetchQuery` 기반으로 전환
  - add/update/delete 이후 invalidate/removeQueries 정책 적용
- `src/data/authStore.*`
  - logout 시 query cache clear (세션 데이터 누출 방지)

---

## 🧪 테스트 / 시나리오
### 자동 테스트
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run build`

### 수동 시나리오 (성능/동작 확인)
- [ ] **중복 호출 감소 확인**
  - GroupList → BoardList → BoardDetail 이동/뒤로가기 반복 시
  - DevTools Network에서 동일 리소스 요청이 캐시로 흡수되는지 확인
- [ ] **mutation 이후 최신화 확인**
  - 보드 생성/수정/삭제 후 목록/상세 데이터가 일관되게 갱신되는지 확인
- [ ] **세션 격리 확인**
  - 로그아웃 → 재로그인 시 이전 사용자 캐시가 노출되지 않는지 확인

### 네트워크 지표 기록
- 총 요청 수(before/after)
- 동일 URL 요청 횟수(before/after)
- 재진입 시 로딩 체감(캐시 hit 여부)

---

## 💡 기타
### 리스크 / 대응 / 롤백 플랜
- 리스크: queryKey 설계가 부정확하면 invalidate 누락으로 stale data 가능
- 대응:
  - queryKeys를 단일 팩토리로 집중 관리
  - mutation 후 invalidate 범위를 보수적으로 설정
- 롤백:
  - store에서 `fetchQuery` 래핑을 제거하고 기존 service 직접 호출로 되돌리면 기능 영향 최소

### 체크리스트
- [ ] 중복 호출 감소(네트워크) 확인
- [ ] mutation 후 최신화 확인
- [ ] 로그아웃 후 캐시 초기화 확인
- [ ] CI 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 데이터 캐싱 시스템을 추가하여 앱 성능과 응답성이 향상되었습니다. 그룹 및 보드 데이터는 이제 더 효율적으로 관리되며, 네트워크 요청이 최적화되었습니다. 로그아웃 시 캐시가 자동으로 정리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->